### PR TITLE
Removes SenTestingKit Framework From Podspec

### DIFF
--- a/LoopBack.podspec
+++ b/LoopBack.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.ios.deployment_target = '6.1'
-  s.ios.frameworks = 'UIKit', 'Foundation', 'SenTestingKit'
+  s.ios.frameworks = 'UIKit', 'Foundation'
 
 end


### PR DESCRIPTION
SenTestingKit should normally ever be added to testing targets. In the latest Cocoapods it is recommended that  a projects includes `$(inherited)` in the `other linkers flags` so that it will inherit all dependencies of pods that are installed. Having SenTestingKit there will ultimately lead to the app to crashing on startup when it's been archived for app store or enterprise deployment.

And I've signed the CLA
