### PR TITLE
Fix a subclassing issue in LBModel

### DIFF
--- a/LoopBack/LBModel.m
+++ b/LoopBack/LBModel.m
@@ -56,17 +56,19 @@
 
     [dict setValue:__id forKey:@"id"];
 
-    unsigned int propertyCount, i;
-    objc_property_t *properties = class_copyPropertyList([self class], &propertyCount);
-    NSString *propertyName;
+    for (Class targetClass = [self class]; targetClass != [LBModel superclass]; targetClass = [targetClass superclass]) {
+        unsigned int propertyCount, i;
+        objc_property_t *properties = class_copyPropertyList(targetClass, &propertyCount);
+        NSString *propertyName;
 
-    for (i = 0; i < propertyCount; i++) {
-        propertyName = [NSString stringWithCString:property_getName(properties[i]) encoding:NSUTF8StringEncoding];
-        if ([propertyName isEqualToString:@"_id"]) {
-            continue;
+        for (i = 0; i < propertyCount; i++) {
+            propertyName = [NSString stringWithCString:property_getName(properties[i]) encoding:NSUTF8StringEncoding];
+            if ([propertyName isEqualToString:@"_id"]) {
+                continue;
+            }
+
+            [dict setValue:[self valueForKey:propertyName] forKey:propertyName];
         }
-
-        [dict setValue:[self valueForKey:propertyName] forKey:propertyName];
     }
 
     return dict;

--- a/LoopBackTests/LBUserTests.m
+++ b/LoopBackTests/LBUserTests.m
@@ -11,9 +11,38 @@
 #import "LBUser.h"
 #import "LBRESTAdapter.h"
 
+/**
+ * Custom subclass of User.
+ */
+@interface Customer : LBUser
+
+@end
+
+@implementation Customer
+
+@end
+
+/**
+ * Repository for our custom User subclass.
+ */
+@interface CustomerRepository : LBUserRepository
+
++ (instancetype)repository;
+
+@end
+
+@implementation CustomerRepository
+
++ (instancetype)repository {
+	return [self repositoryWithClassName:@"customers"];
+}
+
+@end
+
+
 @interface LBUserTests ()
 
-@property (nonatomic, strong) LBUserRepository *repository;
+@property (nonatomic, strong) CustomerRepository *repository;
 
 @end
 
@@ -36,7 +65,7 @@
     [super setUp];
     
     LBRESTAdapter *adapter = [LBRESTAdapter adapterWithURL:[NSURL URLWithString:@"http://localhost:3000"]];
-    self.repository = (LBUserRepository*)[adapter repositoryWithClass:[LBUserRepository class]];
+    self.repository = (CustomerRepository*)[adapter repositoryWithClass:[CustomerRepository class]];
 }
 
 - (void)tearDown {
@@ -45,8 +74,8 @@
 
 - (void)testCreate {
     ASYNC_TEST_START
-    LBUser __block *user = [self.repository createUserWithEmail:@"testUser@test.com"
-                                                       password:@"test"];
+    Customer __block *user = (Customer*)[self.repository createUserWithEmail:@"testUser@test.com"
+                                                                    password:@"test"];
     [user saveWithSuccess:^{
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];

--- a/LoopBackTests/server/index.js
+++ b/LoopBackTests/server/index.js
@@ -57,7 +57,7 @@ Widget.destroyAll(function () {
 
 app.model(loopback.AccessToken);
 
-app.model('User', {
+app.model('Customer', {
   options: {
     base: 'User',
     relations: {


### PR DESCRIPTION
Make toDictionary iterate through superclasses up until LBModel when applied to a subclass of LBModel.
Update LBUserTests to test a subclass of LBUser, which effectively checks this fix of LBModel's subclassing issue.  Without the fix, properties like email and password will not get sent correctly and the test fails.

Since LBModel only defines single property "id" and it is handled independently at Line 57, the for-loop termination condition at Line 59 could have been "targetClass != [LBModel class]" and Lines 66, 67, 68 could have been removed.  However, those are kept as they are considering future possibility of adding a new property to LBModel which may better be handled in the regular manner.