### PR TITLE
Preserve REST access token across application restarts

### DIFF
--- a/LoopBack.xcodeproj/project.pbxproj
+++ b/LoopBack.xcodeproj/project.pbxproj
@@ -123,6 +123,8 @@
 		47D471AF196DF4A1002E2358 /* SLRemotingTests-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BC41962123900995044 /* SLRemotingTests-Info.plist */; };
 		47F8E813185B7A4E0088BB73 /* LBPushNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 47F8E811185B7A4E0088BB73 /* LBPushNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		47F8E814185B7A4E0088BB73 /* LBPushNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 47F8E812185B7A4E0088BB73 /* LBPushNotification.m */; };
+		89CAC10B1A8E273200FF028D /* LBRESTAdapterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89CAC10A1A8E273200FF028D /* LBRESTAdapterTests.m */; };
+		89CAC10C1A8E273200FF028D /* LBRESTAdapterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89CAC10A1A8E273200FF028D /* LBRESTAdapterTests.m */; };
 		B3D220FB17722AE800B7CB63 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220FA17722AE800B7CB63 /* Foundation.framework */; };
 		B3D2210A17722AE800B7CB63 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2210917722AE800B7CB63 /* SenTestingKit.framework */; };
 		B3D2210D17722AE800B7CB63 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220FA17722AE800B7CB63 /* Foundation.framework */; };
@@ -240,6 +242,7 @@
 		47D471B8196DF4A1002E2358 /* LoopBackTests copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "LoopBackTests copy-Info.plist"; path = "/Users/rfeng/Projects/loopback/loopback-sdk-ios/LoopBackTests copy-Info.plist"; sourceTree = "<absolute>"; };
 		47F8E811185B7A4E0088BB73 /* LBPushNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LBPushNotification.h; sourceTree = "<group>"; };
 		47F8E812185B7A4E0088BB73 /* LBPushNotification.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBPushNotification.m; sourceTree = "<group>"; };
+		89CAC10A1A8E273200FF028D /* LBRESTAdapterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBRESTAdapterTests.m; sourceTree = "<group>"; };
 		B3D220F717722AE800B7CB63 /* libLoopBack.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libLoopBack.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3D220FA17722AE800B7CB63 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		B3D220FE17722AE800B7CB63 /* LoopBack-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LoopBack-Prefix.pch"; sourceTree = "<group>"; };
@@ -471,6 +474,7 @@
 				B3D2214117725A7F00B7CB63 /* LBModelSubclassingTests.m */,
 				0B3A201918A57D55006772C8 /* LBUserTests.h */,
 				0B3A201718A57CCD006772C8 /* LBUserTests.m */,
+				89CAC10A1A8E273200FF028D /* LBRESTAdapterTests.m */,
 			);
 			path = LoopBackTests;
 			sourceTree = "<group>";
@@ -719,6 +723,7 @@
 				47D4719A196DF4A1002E2358 /* SLRESTAdapterSSLTests.m in Sources */,
 				47D4719B196DF4A1002E2358 /* SLRESTAdapterNonRootTests.m in Sources */,
 				47D4719C196DF4A1002E2358 /* LBModelSubclassingTests.m in Sources */,
+				89CAC10C1A8E273200FF028D /* LBRESTAdapterTests.m in Sources */,
 				47D4719D196DF4A1002E2358 /* contract.js in Sources */,
 				47D4719E196DF4A1002E2358 /* nonroot.js in Sources */,
 				47D4719F196DF4A1002E2358 /* LBInstallationTests.m in Sources */,
@@ -772,6 +777,7 @@
 				47C48BDA1962123900995044 /* SLRESTAdapterSSLTests.m in Sources */,
 				47C48BD91962123900995044 /* SLRESTAdapterNonRootTests.m in Sources */,
 				B3D2214217725A7F00B7CB63 /* LBModelSubclassingTests.m in Sources */,
+				89CAC10B1A8E273200FF028D /* LBRESTAdapterTests.m in Sources */,
 				47C48BCF1962123900995044 /* contract.js in Sources */,
 				47C48BD11962123900995044 /* nonroot.js in Sources */,
 				4769FF09184D6F4F00E5152C /* LBInstallationTests.m in Sources */,

--- a/LoopBack/LBRESTAdapter.m
+++ b/LoopBack/LBRESTAdapter.m
@@ -7,13 +7,32 @@
 
 #import "LBRESTAdapter.h"
 
+static NSString * const DEFAULTS_ACCESSTOKEN_KEY = @"LBRESTAdapterAccessToken";
+
 @interface LBRESTAdapter()
 
 - (void)attachRepository:(LBModelRepository *)repository;
+- (void)saveAccessToken:(NSString *)accessToken;
+- (NSString *)loadAccessToken;
 
 @end
 
 @implementation LBRESTAdapter
+
+- (instancetype)initWithURL:(NSURL *)url allowsInvalidSSLCertificate : (BOOL) allowsInvalidSSLCertificate {
+    self = [super initWithURL:url allowsInvalidSSLCertificate:allowsInvalidSSLCertificate];
+
+    if (self) {
+        self.accessToken = [self loadAccessToken];
+    }
+
+    return self;
+}
+
+- (void)setAccessToken:(NSString *)accessToken {
+    super.accessToken = accessToken;
+    [self saveAccessToken:accessToken];
+}
 
 - (LBModelRepository *)repositoryWithModelName:(NSString *)name {
     NSParameterAssert(name);
@@ -40,6 +59,17 @@
 - (void)attachRepository:(LBModelRepository *)repository {
     [self.contract addItemsFromContract:[repository contract]];
     repository.adapter = self;
+}
+
+- (void)saveAccessToken:(NSString *)accessToken {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setObject:accessToken forKey:DEFAULTS_ACCESSTOKEN_KEY];
+}
+
+- (NSString *)loadAccessToken {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *accessToken = [defaults objectForKey:DEFAULTS_ACCESSTOKEN_KEY];
+    return accessToken;
 }
 
 @end

--- a/LoopBack/LBUser.m
+++ b/LoopBack/LBUser.m
@@ -89,6 +89,8 @@
     [self invokeStaticMethod:@"logout"
                   parameters:nil
                      success:^(id value) {
+                         LBRESTAdapter* adapter = (LBRESTAdapter*)self.adapter;
+                         adapter.accessToken = nil;
                          success();
                      }
                      failure:failure];

--- a/LoopBackTests/LBRESTAdapterTests.m
+++ b/LoopBackTests/LBRESTAdapterTests.m
@@ -1,0 +1,45 @@
+//
+//  LBRESTAdapterTests.m
+//  LoopBack
+//
+//  Copyright (c) 2015 StrongLoop. All rights reserved.
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+
+#import "LBRESTAdapter.h"
+
+static NSString * const SERVER_URL = @"http://localhost:3001";
+
+@interface LBRESTAdapterTests : SenTestCase
+
+@property (nonatomic, strong) LBRESTAdapter *adapter;
+
+@end
+
+@implementation LBRESTAdapterTests
+
+- (void)setUp {
+    [super setUp];
+    self.adapter = [LBRESTAdapter adapterWithURL:[NSURL URLWithString:SERVER_URL]];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testAccessTokenIsStoredInSharedPreferences {
+    self.adapter.accessToken = @"an-access-token";
+
+    LBRESTAdapter *anotherAdapter = [LBRESTAdapter adapterWithURL:[NSURL URLWithString:SERVER_URL]];
+    STAssertEqualObjects(anotherAdapter.accessToken, @"an-access-token", @"Invalid access token");
+
+    self.adapter.accessToken = @"a-different-access-token";
+
+    LBRESTAdapter *yetAnotherAdapter = [LBRESTAdapter adapterWithURL:[NSURL URLWithString:SERVER_URL]];
+    STAssertEqualObjects(yetAnotherAdapter.accessToken, @"a-different-access-token", @"Invalid access token");
+
+    self.adapter.accessToken = nil;
+}
+
+@end


### PR DESCRIPTION
Make RestAdapter store the access token in NSUserDefaults, which is a per-app shared persistent storage and typically used for keeping app preferences and such.

Add a test to check if the access token is stored in the app-wide shared persistent storage -- if the token is successfully stored and reused, the value will be shared among independently constructed adapters.

/to @bajtos could you please review?
FYI, NSUserDefaults is something similar to Android's context.getSharedPreferences( , Context.MODE_PRIVATE);
As to LBRESTAdapterTests.m, I used a different approach than Android's RestAdapterTest.java.
Hope it still looks fine.
