### PR TITLE
Implement UserRepository.currentUserId

### DIFF
--- a/LoopBack/LBUser.h
+++ b/LoopBack/LBUser.h
@@ -29,6 +29,8 @@
  */
 @interface LBUserRepository : LBModelRepository
 
+@property (nonatomic, readonly) NSString *currentUserId;
+
 + (instancetype)repository;
 
 /**

--- a/LoopBack/LBUser.h
+++ b/LoopBack/LBUser.h
@@ -30,6 +30,7 @@
 @interface LBUserRepository : LBModelRepository
 
 @property (nonatomic, readonly) NSString *currentUserId;
+@property (nonatomic, readonly) LBUser *cachedCurrentUser;
 
 + (instancetype)repository;
 
@@ -55,7 +56,7 @@
 
 /**
  * Blocks of this type are executed when
- * LBUserRepository::login:success:failure: is successful.
+ * LBUserRepository::loginWithEmail:password:success:failure: is successful.
  */
 typedef void (^LBUserLoginSuccessBlock)(LBAccessToken* token);
 /**
@@ -74,7 +75,7 @@ typedef void (^LBUserLoginSuccessBlock)(LBAccessToken* token);
 
 /**
  * Blocks of this type are executed when
- * LBUserRepository::login:success:failure: is successful.
+ * LBUserRepository::userByLoginWithEmail:password:success:failure: is successful.
  */
 typedef void (^LBUserLoginFindUserSuccessBlock)(LBUser *user);
 /**
@@ -91,7 +92,22 @@ typedef void (^LBUserLoginFindUserSuccessBlock)(LBUser *user);
                      failure:(SLFailureBlock)failure;
 
 /**
- * Blocks of this type are executed when LBUserRepository::logoutWithSuccess: is
+ * Blocks of this type are executed when
+ * LBUserRepository::findCurrentUserWithSuccess:failure: is successful.
+ */
+typedef void (^LBUserFindUserSuccessBlock)(LBUser *user);
+/**
+ * Fetch the user model of the currently logged in user.
+ * Invokes {@code success(nil)} when no user is logged in.
+ *
+ * @param success  The block to be executed when the fetch is successful.
+ * @param failure  The block to be executed when the fetch fails.
+ */
+- (void)findCurrentUserWithSuccess:(LBUserFindUserSuccessBlock)success
+                           failure:(SLFailureBlock)failure;
+
+/**
+ * Blocks of this type are executed when LBUserRepository::logoutWithSuccess:success:failure: is
  * successful.
  */
 typedef void (^LBUserLogoutSuccessBlock)();

--- a/LoopBack/LBUser.m
+++ b/LoopBack/LBUser.m
@@ -22,6 +22,7 @@ static NSString * const DEFAULTS_CURRENT_USER_ID_KEY = @"LBUserRepositoryCurrent
 @property (nonatomic, strong) LBAccessTokenRepository *accessTokenRepository;
 @property (nonatomic, readwrite) NSString *currentUserId;
 @property BOOL isCurrentUserIdLoaded;
+@property (nonatomic, readwrite) LBUser *cachedCurrentUser;
 
 - (void)loadCurrentUserIdIfNotLoaded;
 - (void)saveCurrentUserId;
@@ -92,8 +93,22 @@ static NSString * const DEFAULTS_CURRENT_USER_ID_KEY = @"LBUserRepositoryCurrent
     NSParameterAssert(password);
     [self loginWithEmail:email password:password success:^(LBAccessToken* token){
         [self findById:token.userId success:^(LBModel *model){
+            self.cachedCurrentUser = (LBUser*)model;
             success((LBUser*)model);
         } failure:failure];
+    } failure:failure];
+}
+
+- (void)findCurrentUserWithSuccess:(LBUserFindUserSuccessBlock)success
+                           failure:(SLFailureBlock)failure {
+    if (self.currentUserId == nil) {
+        success(nil);
+        return;
+    }
+
+    [self findById:self.currentUserId success:^(LBModel *model) {
+        self.cachedCurrentUser = (LBUser*)model;
+        success((LBUser*)model);
     } failure:failure];
 }
 
@@ -117,6 +132,7 @@ static NSString * const DEFAULTS_CURRENT_USER_ID_KEY = @"LBUserRepositoryCurrent
 
 - (void)setCurrentUserId:(NSString *)currentUserId {
     _currentUserId = currentUserId;
+    self.cachedCurrentUser = nil;
     [self saveCurrentUserId];
 }
 

--- a/LoopBackTests/LBUserTests.m
+++ b/LoopBackTests/LBUserTests.m
@@ -11,6 +11,10 @@
 #import "LBUser.h"
 #import "LBRESTAdapter.h"
 
+static NSString * const DEFAULTS_CURRENT_USER_ID_KEY = @"LBUserRepositoryCurrentUserId";
+static NSString * const USER_EMAIL_DOMAIN = @"@test.com";
+static NSString * const USER_PASSWORD = @"testpassword";
+
 /**
  * Custom subclass of User.
  */
@@ -45,6 +49,10 @@
 @property (nonatomic, strong) LBRESTAdapter *adapter;
 @property (nonatomic, strong) CustomerRepository *repository;
 
+typedef void (^GivenCustomerSuccessBlock)(Customer *customer);
+- (void)givenCustomerWithSuccess:(GivenCustomerSuccessBlock)success failure:(SLFailureBlock)failure;
+- (void)givenLoggedInCustomerWithSuccess:(GivenCustomerSuccessBlock)success failure:(SLFailureBlock)failure;
+
 @end
 
 @implementation LBUserTests
@@ -54,20 +62,26 @@
  */
 + (id)defaultTestSuite {
     SenTestSuite *suite = [SenTestSuite testSuiteWithName:@"TestSuite for LBContainer."];
-    [suite addTest:[self testCaseWithSelector:@selector(testCreate)]];
-    [suite addTest:[self testCaseWithSelector:@selector(testLogin)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testCreateSaveRemove)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testLoginLogout)]];
     [suite addTest:[self testCaseWithSelector:@selector(testSetsCurrentUserIdOnLogin)]];
     [suite addTest:[self testCaseWithSelector:@selector(testCurrentUserIdIsStoredInSharedPreferences)]];
-    [suite addTest:[self testCaseWithSelector:@selector(testLogout)]];
     [suite addTest:[self testCaseWithSelector:@selector(testClearsCurrentUserIdOnLogout)]];
-    [suite addTest:[self testCaseWithSelector:@selector(testRemove)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testGetCachedCurrentUserReturnsNilInitially)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testFindCurrentUserReturnsNilWhenNotLoggedIn)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testFindCurrentUserReturnsCorrectValue)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testGetCachedCurrentUserReturnsValueLoadedByFindCurrentUser)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testGetCachedCurrentUserReturnsValueLoadedByLogin)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testCachedCurrentUserIsClearedOnLogout)]];
     return suite;
 }
 
-
 - (void)setUp {
     [super setUp];
-    
+    // forcibly clear the stored user id
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults removeObjectForKey:DEFAULTS_CURRENT_USER_ID_KEY];
+
     self.adapter = [LBRESTAdapter adapterWithURL:[NSURL URLWithString:@"http://localhost:3000"]];
     self.repository = (CustomerRepository*)[self.adapter repositoryWithClass:[CustomerRepository class]];
 }
@@ -76,28 +90,47 @@
     [super tearDown];
 }
 
-- (void)testCreate {
+- (void)testCreateSaveRemove {
     ASYNC_TEST_START
-    Customer __block *user = (Customer*)[self.repository createUserWithEmail:@"testUser@test.com"
-                                                                    password:@"test"];
-    [user saveWithSuccess:^{
-        ASYNC_TEST_SIGNAL
+    double uid = [[NSDate date] timeIntervalSince1970];
+    NSString *userEmail = [NSString stringWithFormat:@"%f%@", uid, USER_EMAIL_DOMAIN];
+
+    Customer __block *customer = (Customer*)[self.repository createUserWithEmail:userEmail
+                                                                        password:USER_PASSWORD];
+    STAssertNil(customer._id, @"User id should be nil before save");
+
+    [customer saveWithSuccess:^{
+        STAssertNotNil(customer._id, @"User id should not be nil after save");
+
+        [self.repository userByLoginWithEmail:userEmail password:USER_PASSWORD success:^(LBUser *user) {
+            [user destroyWithSuccess:^(void) {
+                ASYNC_TEST_SIGNAL
+            } failure:ASYNC_TEST_FAILURE_BLOCK];
+        } failure:ASYNC_TEST_FAILURE_BLOCK];
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
 }
 
-- (void)testLogin {
+- (void)testLoginLogout {
     ASYNC_TEST_START
-    [self.repository userByLoginWithEmail:@"testUser@test.com" password:@"test" success:^(LBUser* user) {
-        ASYNC_TEST_SIGNAL
+    [self givenCustomerWithSuccess:^(Customer *customer) {
+        [self.repository userByLoginWithEmail:customer.email password:USER_PASSWORD success:^(LBUser *user) {
+            STAssertNotNil(user, @"User should not be nil");
+            STAssertNotNil(user._id, @"User id should not be nil");
+            STAssertEqualObjects(user.email, customer.email, @"Invalid email");
+
+            [self.repository logoutWithSuccess:^(void) {
+                ASYNC_TEST_SIGNAL
+            } failure:ASYNC_TEST_FAILURE_BLOCK];
+        } failure:ASYNC_TEST_FAILURE_BLOCK];
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
 }
 
 - (void)testSetsCurrentUserIdOnLogin {
     ASYNC_TEST_START
-    [self.repository userByLoginWithEmail:@"testUser@test.com" password:@"test" success:^(LBUser* user) {
-        STAssertEqualObjects(user._id, self.repository.currentUserId, @"Invalid current user ID");
+    [self givenLoggedInCustomerWithSuccess:^(Customer *customer) {
+        STAssertEqualObjects(customer._id, self.repository.currentUserId, @"Invalid current user ID");
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -105,48 +138,116 @@
 
 - (void)testCurrentUserIdIsStoredInSharedPreferences {
     ASYNC_TEST_START
-    [self.repository userByLoginWithEmail:@"testUser@test.com" password:@"test" success:^(LBUser* user) {
+    [self givenLoggedInCustomerWithSuccess:^(Customer *customer) {
         CustomerRepository *anotherRepo = (CustomerRepository*)[self.adapter repositoryWithClass:[CustomerRepository class]];
-        STAssertEqualObjects(user._id, anotherRepo.currentUserId, @"Invalid current user ID");
+        STAssertEqualObjects(customer._id, anotherRepo.currentUserId, @"Invalid current user ID");
         ASYNC_TEST_SIGNAL
-    } failure:ASYNC_TEST_FAILURE_BLOCK];
-    ASYNC_TEST_END
-}
-
-- (void)testLogout {
-    ASYNC_TEST_START
-    [self.repository userByLoginWithEmail:@"testUser@test.com" password:@"test" success:^(LBUser* user) {
-        [self.repository logoutWithSuccess:^(void) {
-            // The following second try to logout should fail if the first logout succeeded
-            [self.repository logoutWithSuccess:ASYNC_TEST_FAILURE_BLOCK
-            failure:^(NSError *error) {
-                ASYNC_TEST_SIGNAL
-            }];
-        } failure:ASYNC_TEST_FAILURE_BLOCK];
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
 }
 
 - (void)testClearsCurrentUserIdOnLogout {
     ASYNC_TEST_START
-    [self.repository userByLoginWithEmail:@"testUser@test.com" password:@"test" success:^(LBUser* user) {
-        STAssertEqualObjects(user._id, self.repository.currentUserId, @"Invalid current user ID");
+    [self givenLoggedInCustomerWithSuccess:^(Customer *customer) {
+        STAssertEqualObjects(customer._id, self.repository.currentUserId, @"Invalid current user ID");
         [self.repository logoutWithSuccess:^(void) {
-            STAssertEqualObjects(nil, self.repository.currentUserId, @"Invalid current user ID");
+            STAssertNil(self.repository.currentUserId, @"Invalid current user ID");
+            // The following second try to logout should fail if the first logout succeeded
+            [self.repository logoutWithSuccess:ASYNC_TEST_FAILURE_BLOCK
+                                       failure:^(NSError *error) {
+                                           ASYNC_TEST_SIGNAL
+                                       }];
+        } failure:ASYNC_TEST_FAILURE_BLOCK];
+    } failure:ASYNC_TEST_FAILURE_BLOCK];
+    ASYNC_TEST_END
+}
+
+- (void)testGetCachedCurrentUserReturnsNilInitially {
+    LBUser *cached = self.repository.cachedCurrentUser;
+    STAssertNil(cached, @"Cached current user should be nil initially");
+}
+
+- (void)testFindCurrentUserReturnsNilWhenNotLoggedIn {
+    ASYNC_TEST_START
+    [self.repository findCurrentUserWithSuccess:^(LBUser *current) {
+        STAssertNil(current, @"Current user should be nil when not logged in");
+        ASYNC_TEST_SIGNAL
+    } failure:ASYNC_TEST_FAILURE_BLOCK];
+    ASYNC_TEST_END
+}
+
+- (void)testFindCurrentUserReturnsCorrectValue {
+    ASYNC_TEST_START
+    [self givenLoggedInCustomerWithSuccess:^(Customer *customer) {
+        [self.repository findCurrentUserWithSuccess:^(LBUser *current) {
+            STAssertEqualObjects(customer._id, current._id, @"Invalid current user");
+            STAssertEqualObjects(customer.email, current.email, @"Invalid current user");
             ASYNC_TEST_SIGNAL
         } failure:ASYNC_TEST_FAILURE_BLOCK];
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
 }
 
-- (void)testRemove {
+- (void)testGetCachedCurrentUserReturnsValueLoadedByFindCurrentUser {
     ASYNC_TEST_START
-    [self.repository userByLoginWithEmail:@"testUser@test.com" password:@"test" success:^(LBUser* user) {
-        [user destroyWithSuccess:^(void) {
+    [self givenLoggedInCustomerWithSuccess:^(Customer *customer) {
+        [self.repository findCurrentUserWithSuccess:^(LBUser *current) {
+            LBUser *cached = self.repository.cachedCurrentUser;
+            STAssertEqualObjects(current, cached, @"Invalid cached current user");
             ASYNC_TEST_SIGNAL
         } failure:ASYNC_TEST_FAILURE_BLOCK];
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
+}
+
+- (void)testGetCachedCurrentUserReturnsValueLoadedByLogin {
+    ASYNC_TEST_START
+    [self givenLoggedInCustomerWithSuccess:^(Customer *customer) {
+        LBUser *cached = self.repository.cachedCurrentUser;
+        STAssertEqualObjects(customer, cached, @"Invalid cached current user");
+        ASYNC_TEST_SIGNAL
+    } failure:ASYNC_TEST_FAILURE_BLOCK];
+    ASYNC_TEST_END
+}
+
+- (void)testCachedCurrentUserIsClearedOnLogout {
+    ASYNC_TEST_START
+    [self givenLoggedInCustomerWithSuccess:^(Customer *customer) {
+        [self.repository logoutWithSuccess:^(void) {
+            LBUser *cached = self.repository.cachedCurrentUser;
+            STAssertNil(cached, @"Cached current user should be nil after logout");
+            ASYNC_TEST_SIGNAL
+        } failure:ASYNC_TEST_FAILURE_BLOCK];
+    } failure:ASYNC_TEST_FAILURE_BLOCK];
+    ASYNC_TEST_END
+}
+
+- (void)givenCustomerWithSuccess:(GivenCustomerSuccessBlock)success
+                         failure:(SLFailureBlock)failure {
+    static int counter = 0;
+
+    double uid = [[NSDate date] timeIntervalSince1970];
+    NSString *email = [NSString stringWithFormat:@"%f-%d%@", uid, ++counter, USER_EMAIL_DOMAIN];
+
+    Customer __block *user = (Customer*)[self.repository createUserWithEmail:email password:USER_PASSWORD];
+    [user saveWithSuccess:^{
+        success(user);
+    } failure:^(NSError *error) {
+        NSLog(@"givenCustomerWithSuccess failed with error: %@", error);
+        failure(error);
+    }];
+}
+
+- (void)givenLoggedInCustomerWithSuccess:(GivenCustomerSuccessBlock)success
+                                 failure:(SLFailureBlock)failure {
+    [self givenCustomerWithSuccess:^(Customer *customer) {
+        [self.repository userByLoginWithEmail:customer.email password:USER_PASSWORD success:^(LBUser *user) {
+            success((Customer*)user);
+        } failure:^(NSError *error) {
+            NSLog(@"givenLoggedInCustomerWithSuccess failed with error: %@", error);
+            failure(error);
+        }];
+    } failure:failure];
 }
 
 @end

--- a/SLRemotingTests/SLRESTContractTests.m
+++ b/SLRemotingTests/SLRESTContractTests.m
@@ -156,7 +156,7 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
 - (void)testCustomRequestHeader {
     ASYNC_TEST_START
     SLRESTAdapter *customAdapter = [SLRESTAdapter adapterWithURL:[NSURL URLWithString:SERVER_URL]];
-    [customAdapter setAccessToken:@"auth-token"];
+    customAdapter.accessToken = @"auth-token";
 
     [customAdapter.contract addItem:[SLRESTContractItem itemWithPattern:@"/contract/get-auth" verb:@"GET"] forMethod:@"contract.getAuthorizationHeader"];
 


### PR DESCRIPTION
Implement UserRepository.currentUserId

The id is set by the login and cleared by the logout methods.
The id is preserved in NSUserDefaults across app restarts.

/to @bajtos could you please review?