### PR TITLE
Fix implementation issues found in LBFile and SLRESTAdapter

### DIFF
--- a/LoopBack.xcodeproj/project.pbxproj
+++ b/LoopBack.xcodeproj/project.pbxproj
@@ -106,6 +106,8 @@
 		895B41811AB16D670000A9D7 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B278D50187B584F00FFC135 /* MobileCoreServices.framework */; };
 		895B41821AB16D6A0000A9D7 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B278D4A187B584A00FFC135 /* SystemConfiguration.framework */; };
 		895B41831AB16D6B0000A9D7 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B278D4A187B584A00FFC135 /* SystemConfiguration.framework */; };
+		8973753E1AB2A60A00FB31A2 /* SLStreamParam.h in Headers */ = {isa = PBXBuildFile; fileRef = 8973753C1AB2A60A00FB31A2 /* SLStreamParam.h */; };
+		8973753F1AB2A60A00FB31A2 /* SLStreamParam.m in Sources */ = {isa = PBXBuildFile; fileRef = 8973753D1AB2A60A00FB31A2 /* SLStreamParam.m */; };
 		89D3DB0E1AB174F1005A1B90 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BB51962123900995044 /* InfoPlist.strings */; };
 		89D3DB0F1AB174F1005A1B90 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BB51962123900995044 /* InfoPlist.strings */; };
 		89EB399D1AB16ED700B1EB9D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2214317725DAB00B7CB63 /* UIKit.framework */; };
@@ -225,6 +227,8 @@
 		47D471B7196DF4A1002E2358 /* LoopBackTests copy.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "LoopBackTests copy.octest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		47F8E811185B7A4E0088BB73 /* LBPushNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LBPushNotification.h; sourceTree = "<group>"; };
 		47F8E812185B7A4E0088BB73 /* LBPushNotification.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBPushNotification.m; sourceTree = "<group>"; };
+		8973753C1AB2A60A00FB31A2 /* SLStreamParam.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SLStreamParam.h; sourceTree = "<group>"; };
+		8973753D1AB2A60A00FB31A2 /* SLStreamParam.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLStreamParam.m; sourceTree = "<group>"; };
 		89D3C9521AB17258005A1B90 /* index.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = index.js; sourceTree = "<group>"; };
 		89D3DB001AB17263005A1B90 /* package.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = package.json; sourceTree = "<group>"; };
 		89D3DB031AB17263005A1B90 /* f1.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = f1.txt; sourceTree = "<group>"; };
@@ -321,7 +325,6 @@
 		47C48B881962120E00995044 /* SLRemoting */ = {
 			isa = PBXGroup;
 			children = (
-				89D3DB111AB178B7005A1B90 /* Supporting File */,
 				47C48B891962120E00995044 /* SLAdapter.h */,
 				47C48B8A1962120E00995044 /* SLAdapter.m */,
 				47C48B8B1962120E00995044 /* SLObject.h */,
@@ -333,6 +336,9 @@
 				47C48B921962120E00995044 /* SLRESTAdapter.m */,
 				47C48B931962120E00995044 /* SLRESTContract.h */,
 				47C48B941962120E00995044 /* SLRESTContract.m */,
+				8973753C1AB2A60A00FB31A2 /* SLStreamParam.h */,
+				8973753D1AB2A60A00FB31A2 /* SLStreamParam.m */,
+				89D3DB111AB178B7005A1B90 /* Supporting File */,
 			);
 			path = SLRemoting;
 			sourceTree = "<group>";
@@ -340,8 +346,6 @@
 		47C48BB41962123900995044 /* SLRemotingTests */ = {
 			isa = PBXGroup;
 			children = (
-				89D3DB101AB175C7005A1B90 /* Supporting Files */,
-				47C48BB71962123900995044 /* server */,
 				47C48BC81962123900995044 /* SLRESTAdapterTests.h */,
 				47C48BC91962123900995044 /* SLRESTAdapterTests.m */,
 				47C48BCA1962123900995044 /* SLRESTContractTests.h */,
@@ -349,6 +353,8 @@
 				47C48BC51962123900995044 /* SLRESTAdapterNonRootTests.h */,
 				47C48BC61962123900995044 /* SLRESTAdapterNonRootTests.m */,
 				47C48BC71962123900995044 /* SLRESTAdapterSSLTests.m */,
+				89D3DB101AB175C7005A1B90 /* Supporting Files */,
+				47C48BB71962123900995044 /* server */,
 			);
 			path = SLRemotingTests;
 			sourceTree = "<group>";
@@ -356,16 +362,16 @@
 		47C48BB71962123900995044 /* server */ = {
 			isa = PBXGroup;
 			children = (
-				47C48BB81962123900995044 /* .gitignore */,
 				47C48BB91962123900995044 /* contract-class.js */,
 				47C48BBA1962123900995044 /* contract.js */,
 				47C48BBB1962123900995044 /* index.js */,
 				47C48BBC1962123900995044 /* nonroot.js */,
-				47C48BBD1962123900995044 /* package.json */,
-				47C48BBE1962123900995044 /* private */,
 				47C48BC11962123900995044 /* simple-class.js */,
 				47C48BC21962123900995044 /* simple.js */,
 				47C48BC31962123900995044 /* ssl-config.js */,
+				47C48BBD1962123900995044 /* package.json */,
+				47C48BB81962123900995044 /* .gitignore */,
+				47C48BBE1962123900995044 /* private */,
 			);
 			path = server;
 			sourceTree = "<group>";
@@ -472,7 +478,6 @@
 		B3D220FC17722AE800B7CB63 /* LoopBack */ = {
 			isa = PBXGroup;
 			children = (
-				B3D220FD17722AE800B7CB63 /* Supporting Files */,
 				B3D220FF17722AE800B7CB63 /* LoopBack.h */,
 				B3D2212217722B1700B7CB63 /* LBModel.h */,
 				B3D2212317722B1700B7CB63 /* LBModel.m */,
@@ -490,6 +495,7 @@
 				0B786865189B1C3300AB6782 /* LBFile.m */,
 				0B8022DE18A2F1BA00AF845E /* LBContainer.h */,
 				0B8022E418A2F27600AF845E /* LBContainer.m */,
+				B3D220FD17722AE800B7CB63 /* Supporting Files */,
 			);
 			path = LoopBack;
 			sourceTree = "<group>";
@@ -505,8 +511,6 @@
 		B3D2211117722AE800B7CB63 /* LoopBackTests */ = {
 			isa = PBXGroup;
 			children = (
-				B3D2211217722AE800B7CB63 /* Supporting Files */,
-				89D3C9511AB17258005A1B90 /* server */,
 				B3D2213917722BAB00B7CB63 /* LBModelTests.h */,
 				B3D2213A17722BAB00B7CB63 /* LBModelTests.m */,
 				B3D2214017725A7F00B7CB63 /* LBModelSubclassingTests.h */,
@@ -519,6 +523,8 @@
 				0B3A201A18A5856F006772C8 /* LBFileTests.m */,
 				0B3A200D18A55B5A006772C8 /* LBContainerTests.h */,
 				0B3A201518A56BA5006772C8 /* LBContainerTests.m */,
+				B3D2211217722AE800B7CB63 /* Supporting Files */,
+				89D3C9511AB17258005A1B90 /* server */,
 			);
 			path = LoopBackTests;
 			sourceTree = "<group>";
@@ -552,6 +558,7 @@
 				0B6DCCA518806F2E00F7E57A /* LBUser.h in Headers */,
 				47C48B9D1962120E00995044 /* SLAFNetworkActivityIndicatorManager.h in Headers */,
 				47C48BA81962120E00995044 /* SLAdapter.h in Headers */,
+				8973753E1AB2A60A00FB31A2 /* SLStreamParam.h in Headers */,
 				0B4F52AA18908089004F675A /* LBAccessToken.h in Headers */,
 				47C48BAA1962120E00995044 /* SLObject.h in Headers */,
 				47C48BA61962120E00995044 /* UIImageView+SLAFNetworking.h in Headers */,
@@ -789,6 +796,7 @@
 				47C48BB11962120E00995044 /* SLRESTAdapter.m in Sources */,
 				0B6DCCA618806F2E00F7E57A /* LBUser.m in Sources */,
 				47C48BAB1962120E00995044 /* SLObject.m in Sources */,
+				8973753F1AB2A60A00FB31A2 /* SLStreamParam.m in Sources */,
 				0B8022E518A2F27600AF845E /* LBContainer.m in Sources */,
 				47C48BA31962120E00995044 /* SLAFURLConnectionOperation.m in Sources */,
 				0B786866189B1C3300AB6782 /* LBFile.m in Sources */,

--- a/LoopBack.xcodeproj/project.pbxproj
+++ b/LoopBack.xcodeproj/project.pbxproj
@@ -81,25 +81,12 @@
 		47C48BB11962120E00995044 /* SLRESTAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B921962120E00995044 /* SLRESTAdapter.m */; };
 		47C48BB21962120E00995044 /* SLRESTContract.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B931962120E00995044 /* SLRESTContract.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		47C48BB31962120E00995044 /* SLRESTContract.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B941962120E00995044 /* SLRESTContract.m */; };
-		47C48BCC1962123900995044 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BB51962123900995044 /* InfoPlist.strings */; };
-		47C48BCD1962123900995044 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BB81962123900995044 /* .gitignore */; };
-		47C48BCE1962123900995044 /* contract-class.js in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BB91962123900995044 /* contract-class.js */; };
-		47C48BCF1962123900995044 /* contract.js in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BBA1962123900995044 /* contract.js */; };
-		47C48BD01962123900995044 /* index.js in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BBB1962123900995044 /* index.js */; };
-		47C48BD11962123900995044 /* nonroot.js in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BBC1962123900995044 /* nonroot.js */; };
-		47C48BD21962123900995044 /* package.json in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BBD1962123900995044 /* package.json */; };
-		47C48BD31962123900995044 /* certificate.pem in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BBF1962123900995044 /* certificate.pem */; };
-		47C48BD41962123900995044 /* privatekey.pem in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BC01962123900995044 /* privatekey.pem */; };
-		47C48BD51962123900995044 /* simple-class.js in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC11962123900995044 /* simple-class.js */; };
-		47C48BD61962123900995044 /* simple.js in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC21962123900995044 /* simple.js */; };
-		47C48BD71962123900995044 /* ssl-config.js in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC31962123900995044 /* ssl-config.js */; };
 		47C48BD81962123900995044 /* SLRemotingTests-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BC41962123900995044 /* SLRemotingTests-Info.plist */; };
 		47C48BD91962123900995044 /* SLRESTAdapterNonRootTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC61962123900995044 /* SLRESTAdapterNonRootTests.m */; };
 		47C48BDA1962123900995044 /* SLRESTAdapterSSLTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC71962123900995044 /* SLRESTAdapterSSLTests.m */; };
 		47C48BDB1962123900995044 /* SLRESTAdapterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC91962123900995044 /* SLRESTAdapterTests.m */; };
 		47C48BDC1962123900995044 /* SLRESTContractTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BCB1962123900995044 /* SLRESTContractTests.m */; };
 		47D47194196DF4A1002E2358 /* SLRESTAdapterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC91962123900995044 /* SLRESTAdapterTests.m */; };
-		47D47195196DF4A1002E2358 /* index.js in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BBB1962123900995044 /* index.js */; };
 		47D47196196DF4A1002E2358 /* LBModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2213A17722BAB00B7CB63 /* LBModelTests.m */; };
 		47D47197196DF4A1002E2358 /* SLRESTContractTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BCB1962123900995044 /* SLRESTContractTests.m */; };
 		47D47198196DF4A1002E2358 /* LBContainerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A201518A56BA5006772C8 /* LBContainerTests.m */; };
@@ -107,24 +94,23 @@
 		47D4719A196DF4A1002E2358 /* SLRESTAdapterSSLTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC71962123900995044 /* SLRESTAdapterSSLTests.m */; };
 		47D4719B196DF4A1002E2358 /* SLRESTAdapterNonRootTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC61962123900995044 /* SLRESTAdapterNonRootTests.m */; };
 		47D4719C196DF4A1002E2358 /* LBModelSubclassingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2214117725A7F00B7CB63 /* LBModelSubclassingTests.m */; };
-		47D4719D196DF4A1002E2358 /* contract.js in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BBA1962123900995044 /* contract.js */; };
-		47D4719E196DF4A1002E2358 /* nonroot.js in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BBC1962123900995044 /* nonroot.js */; };
 		47D4719F196DF4A1002E2358 /* LBInstallationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4769FF08184D6F4F00E5152C /* LBInstallationTests.m */; };
 		47D471A0196DF4A1002E2358 /* LBFileTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A201A18A5856F006772C8 /* LBFileTests.m */; };
-		47D471A1196DF4A1002E2358 /* simple-class.js in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC11962123900995044 /* simple-class.js */; };
-		47D471A2196DF4A1002E2358 /* simple.js in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC21962123900995044 /* simple.js */; };
-		47D471A3196DF4A1002E2358 /* ssl-config.js in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC31962123900995044 /* ssl-config.js */; };
-		47D471A4196DF4A1002E2358 /* contract-class.js in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BB91962123900995044 /* contract-class.js */; };
 		47D471A6196DF4A1002E2358 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2210917722AE800B7CB63 /* SenTestingKit.framework */; };
 		47D471A7196DF4A1002E2358 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220FA17722AE800B7CB63 /* Foundation.framework */; };
-		47D471A8196DF4A1002E2358 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2214317725DAB00B7CB63 /* UIKit.framework */; };
 		47D471A9196DF4A1002E2358 /* libLoopBack.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220F717722AE800B7CB63 /* libLoopBack.a */; };
-		47D471AD196DF4A1002E2358 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BB51962123900995044 /* InfoPlist.strings */; };
 		47D471AF196DF4A1002E2358 /* SLRemotingTests-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BC41962123900995044 /* SLRemotingTests-Info.plist */; };
 		47F8E813185B7A4E0088BB73 /* LBPushNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 47F8E811185B7A4E0088BB73 /* LBPushNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		47F8E814185B7A4E0088BB73 /* LBPushNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 47F8E812185B7A4E0088BB73 /* LBPushNotification.m */; };
-		89CAC10B1A8E273200FF028D /* LBRESTAdapterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89CAC10A1A8E273200FF028D /* LBRESTAdapterTests.m */; };
-		89CAC10C1A8E273200FF028D /* LBRESTAdapterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89CAC10A1A8E273200FF028D /* LBRESTAdapterTests.m */; };
+		895B41801AB16D660000A9D7 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B278D50187B584F00FFC135 /* MobileCoreServices.framework */; };
+		895B41811AB16D670000A9D7 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B278D50187B584F00FFC135 /* MobileCoreServices.framework */; };
+		895B41821AB16D6A0000A9D7 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B278D4A187B584A00FFC135 /* SystemConfiguration.framework */; };
+		895B41831AB16D6B0000A9D7 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B278D4A187B584A00FFC135 /* SystemConfiguration.framework */; };
+		89D3DB0E1AB174F1005A1B90 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BB51962123900995044 /* InfoPlist.strings */; };
+		89D3DB0F1AB174F1005A1B90 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BB51962123900995044 /* InfoPlist.strings */; };
+		89EB399D1AB16ED700B1EB9D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2214317725DAB00B7CB63 /* UIKit.framework */; };
+		89EB399E1AB16ED800B1EB9D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2214317725DAB00B7CB63 /* UIKit.framework */; };
+		89EB399F1AB16ED900B1EB9D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2214317725DAB00B7CB63 /* UIKit.framework */; };
 		B3D220FB17722AE800B7CB63 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220FA17722AE800B7CB63 /* Foundation.framework */; };
 		B3D2210A17722AE800B7CB63 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2210917722AE800B7CB63 /* SenTestingKit.framework */; };
 		B3D2210D17722AE800B7CB63 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220FA17722AE800B7CB63 /* Foundation.framework */; };
@@ -133,9 +119,7 @@
 		B3D2212417722B1700B7CB63 /* LBModel.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2212317722B1700B7CB63 /* LBModel.m */; };
 		B3D2213B17722BAB00B7CB63 /* LBModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2213A17722BAB00B7CB63 /* LBModelTests.m */; };
 		B3D2214217725A7F00B7CB63 /* LBModelSubclassingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2214117725A7F00B7CB63 /* LBModelSubclassingTests.m */; };
-		B3D2214417725DAB00B7CB63 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2214317725DAB00B7CB63 /* UIKit.framework */; };
 		B3D2214A1773766800B7CB63 /* LBRESTAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D221491773766800B7CB63 /* LBRESTAdapter.m */; };
-		B3DC030D178F1EE20044DD58 /* libobjc.A.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B3DC030C178F1EE20044DD58 /* libobjc.A.dylib */; };
 		B3DFA5AD17970AB700F656D7 /* LoopBack.h in Headers */ = {isa = PBXBuildFile; fileRef = B3D220FF17722AE800B7CB63 /* LoopBack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3DFA5AE17970ABD00F656D7 /* LBModel.h in Headers */ = {isa = PBXBuildFile; fileRef = B3D2212217722B1700B7CB63 /* LBModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3DFA5AF17970ABD00F656D7 /* LBRESTAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = B3D221481773766800B7CB63 /* LBRESTAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -239,10 +223,14 @@
 		47C48BCA1962123900995044 /* SLRESTContractTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SLRESTContractTests.h; sourceTree = "<group>"; };
 		47C48BCB1962123900995044 /* SLRESTContractTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLRESTContractTests.m; sourceTree = "<group>"; };
 		47D471B7196DF4A1002E2358 /* LoopBackTests copy.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "LoopBackTests copy.octest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		47D471B8196DF4A1002E2358 /* LoopBackTests copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "LoopBackTests copy-Info.plist"; path = "/Users/rfeng/Projects/loopback/loopback-sdk-ios/LoopBackTests copy-Info.plist"; sourceTree = "<absolute>"; };
 		47F8E811185B7A4E0088BB73 /* LBPushNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LBPushNotification.h; sourceTree = "<group>"; };
 		47F8E812185B7A4E0088BB73 /* LBPushNotification.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBPushNotification.m; sourceTree = "<group>"; };
-		89CAC10A1A8E273200FF028D /* LBRESTAdapterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBRESTAdapterTests.m; sourceTree = "<group>"; };
+		89D3C9521AB17258005A1B90 /* index.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = index.js; sourceTree = "<group>"; };
+		89D3DB001AB17263005A1B90 /* package.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = package.json; sourceTree = "<group>"; };
+		89D3DB031AB17263005A1B90 /* f1.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = f1.txt; sourceTree = "<group>"; };
+		89D3DB041AB17263005A1B90 /* f1_downloaded.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = f1_downloaded.txt; sourceTree = "<group>"; };
+		89D3DB051AB17263005A1B90 /* uploadTest.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = uploadTest.txt; sourceTree = "<group>"; };
+		89D3DB071AB17263005A1B90 /* f2.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = f2.txt; sourceTree = "<group>"; };
 		B3D220F717722AE800B7CB63 /* libLoopBack.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libLoopBack.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3D220FA17722AE800B7CB63 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		B3D220FE17722AE800B7CB63 /* LoopBack-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LoopBack-Prefix.pch"; sourceTree = "<group>"; };
@@ -270,7 +258,9 @@
 			files = (
 				47D471A6196DF4A1002E2358 /* SenTestingKit.framework in Frameworks */,
 				47D471A7196DF4A1002E2358 /* Foundation.framework in Frameworks */,
-				47D471A8196DF4A1002E2358 /* UIKit.framework in Frameworks */,
+				895B41811AB16D670000A9D7 /* MobileCoreServices.framework in Frameworks */,
+				895B41831AB16D6B0000A9D7 /* SystemConfiguration.framework in Frameworks */,
+				89EB399D1AB16ED700B1EB9D /* UIKit.framework in Frameworks */,
 				47D471A9196DF4A1002E2358 /* libLoopBack.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -281,8 +271,8 @@
 			files = (
 				0B278D51187B584F00FFC135 /* MobileCoreServices.framework in Frameworks */,
 				0B278D4B187B584A00FFC135 /* SystemConfiguration.framework in Frameworks */,
-				B3DC030D178F1EE20044DD58 /* libobjc.A.dylib in Frameworks */,
 				B3D220FB17722AE800B7CB63 /* Foundation.framework in Frameworks */,
+				89EB399F1AB16ED900B1EB9D /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -292,7 +282,9 @@
 			files = (
 				B3D2210A17722AE800B7CB63 /* SenTestingKit.framework in Frameworks */,
 				B3D2210D17722AE800B7CB63 /* Foundation.framework in Frameworks */,
-				B3D2214417725DAB00B7CB63 /* UIKit.framework in Frameworks */,
+				895B41801AB16D660000A9D7 /* MobileCoreServices.framework in Frameworks */,
+				895B41821AB16D6A0000A9D7 /* SystemConfiguration.framework in Frameworks */,
+				89EB399E1AB16ED800B1EB9D /* UIKit.framework in Frameworks */,
 				B3D2211017722AE800B7CB63 /* libLoopBack.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -329,11 +321,11 @@
 		47C48B881962120E00995044 /* SLRemoting */ = {
 			isa = PBXGroup;
 			children = (
+				89D3DB111AB178B7005A1B90 /* Supporting File */,
 				47C48B891962120E00995044 /* SLAdapter.h */,
 				47C48B8A1962120E00995044 /* SLAdapter.m */,
 				47C48B8B1962120E00995044 /* SLObject.h */,
 				47C48B8C1962120E00995044 /* SLObject.m */,
-				47C48B8D1962120E00995044 /* SLRemoting-Prefix.pch */,
 				47C48B8E1962120E00995044 /* SLRemoting.h */,
 				47C48B8F1962120E00995044 /* SLRemotingUtils.h */,
 				47C48B901962120E00995044 /* SLRemotingUtils.m */,
@@ -348,16 +340,15 @@
 		47C48BB41962123900995044 /* SLRemotingTests */ = {
 			isa = PBXGroup;
 			children = (
-				47C48BB51962123900995044 /* InfoPlist.strings */,
+				89D3DB101AB175C7005A1B90 /* Supporting Files */,
 				47C48BB71962123900995044 /* server */,
-				47C48BC41962123900995044 /* SLRemotingTests-Info.plist */,
-				47C48BC51962123900995044 /* SLRESTAdapterNonRootTests.h */,
-				47C48BC61962123900995044 /* SLRESTAdapterNonRootTests.m */,
-				47C48BC71962123900995044 /* SLRESTAdapterSSLTests.m */,
 				47C48BC81962123900995044 /* SLRESTAdapterTests.h */,
 				47C48BC91962123900995044 /* SLRESTAdapterTests.m */,
 				47C48BCA1962123900995044 /* SLRESTContractTests.h */,
 				47C48BCB1962123900995044 /* SLRESTContractTests.m */,
+				47C48BC51962123900995044 /* SLRESTAdapterNonRootTests.h */,
+				47C48BC61962123900995044 /* SLRESTAdapterNonRootTests.m */,
+				47C48BC71962123900995044 /* SLRESTAdapterSSLTests.m */,
 			);
 			path = SLRemotingTests;
 			sourceTree = "<group>";
@@ -388,17 +379,70 @@
 			path = private;
 			sourceTree = "<group>";
 		};
+		89D3C9511AB17258005A1B90 /* server */ = {
+			isa = PBXGroup;
+			children = (
+				89D3C9521AB17258005A1B90 /* index.js */,
+				89D3DB001AB17263005A1B90 /* package.json */,
+				89D3DB011AB17263005A1B90 /* storage */,
+			);
+			path = server;
+			sourceTree = "<group>";
+		};
+		89D3DB011AB17263005A1B90 /* storage */ = {
+			isa = PBXGroup;
+			children = (
+				89D3DB021AB17263005A1B90 /* container1 */,
+				89D3DB061AB17263005A1B90 /* container2 */,
+			);
+			path = storage;
+			sourceTree = "<group>";
+		};
+		89D3DB021AB17263005A1B90 /* container1 */ = {
+			isa = PBXGroup;
+			children = (
+				89D3DB031AB17263005A1B90 /* f1.txt */,
+				89D3DB041AB17263005A1B90 /* f1_downloaded.txt */,
+				89D3DB051AB17263005A1B90 /* uploadTest.txt */,
+			);
+			path = container1;
+			sourceTree = "<group>";
+		};
+		89D3DB061AB17263005A1B90 /* container2 */ = {
+			isa = PBXGroup;
+			children = (
+				89D3DB071AB17263005A1B90 /* f2.txt */,
+			);
+			path = container2;
+			sourceTree = "<group>";
+		};
+		89D3DB101AB175C7005A1B90 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				47C48BC41962123900995044 /* SLRemotingTests-Info.plist */,
+				47C48BB51962123900995044 /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		89D3DB111AB178B7005A1B90 /* Supporting File */ = {
+			isa = PBXGroup;
+			children = (
+				47C48B8D1962120E00995044 /* SLRemoting-Prefix.pch */,
+			);
+			name = "Supporting File";
+			sourceTree = "<group>";
+		};
 		B3D220EE17722AE800B7CB63 = {
 			isa = PBXGroup;
 			children = (
-				47C48BB41962123900995044 /* SLRemotingTests */,
 				47C48B741962120E00995044 /* SLAFNetworking */,
 				47C48B881962120E00995044 /* SLRemoting */,
+				47C48BB41962123900995044 /* SLRemotingTests */,
 				B3D220FC17722AE800B7CB63 /* LoopBack */,
 				B3D2211117722AE800B7CB63 /* LoopBackTests */,
 				B3D220F917722AE800B7CB63 /* Frameworks */,
 				B3D220F817722AE800B7CB63 /* Products */,
-				47D471B8196DF4A1002E2358 /* LoopBackTests copy-Info.plist */,
 			);
 			sourceTree = "<group>";
 		};
@@ -415,12 +459,12 @@
 		B3D220F917722AE800B7CB63 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				0B278D50187B584F00FFC135 /* MobileCoreServices.framework */,
-				0B278D4A187B584A00FFC135 /* SystemConfiguration.framework */,
 				B3DC030C178F1EE20044DD58 /* libobjc.A.dylib */,
 				B3D220FA17722AE800B7CB63 /* Foundation.framework */,
-				B3D2210917722AE800B7CB63 /* SenTestingKit.framework */,
 				B3D2214317725DAB00B7CB63 /* UIKit.framework */,
+				0B278D50187B584F00FFC135 /* MobileCoreServices.framework */,
+				0B278D4A187B584A00FFC135 /* SystemConfiguration.framework */,
+				B3D2210917722AE800B7CB63 /* SenTestingKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -428,24 +472,24 @@
 		B3D220FC17722AE800B7CB63 /* LoopBack */ = {
 			isa = PBXGroup;
 			children = (
-				47F8E811185B7A4E0088BB73 /* LBPushNotification.h */,
-				47F8E812185B7A4E0088BB73 /* LBPushNotification.m */,
-				47AD031018491DA700F724C8 /* LBInstallation.h */,
-				47AD031118491DA700F724C8 /* LBInstallation.m */,
-				B3D220FF17722AE800B7CB63 /* LoopBack.h */,
 				B3D220FD17722AE800B7CB63 /* Supporting Files */,
+				B3D220FF17722AE800B7CB63 /* LoopBack.h */,
 				B3D2212217722B1700B7CB63 /* LBModel.h */,
 				B3D2212317722B1700B7CB63 /* LBModel.m */,
 				B3D221481773766800B7CB63 /* LBRESTAdapter.h */,
 				B3D221491773766800B7CB63 /* LBRESTAdapter.m */,
+				47AD031018491DA700F724C8 /* LBInstallation.h */,
+				47AD031118491DA700F724C8 /* LBInstallation.m */,
+				47F8E811185B7A4E0088BB73 /* LBPushNotification.h */,
+				47F8E812185B7A4E0088BB73 /* LBPushNotification.m */,
 				0B6DCCA318806F2E00F7E57A /* LBUser.h */,
 				0B6DCCA418806F2E00F7E57A /* LBUser.m */,
 				0B4F52A818908089004F675A /* LBAccessToken.h */,
 				0B4F52A918908089004F675A /* LBAccessToken.m */,
-				0B8022DE18A2F1BA00AF845E /* LBContainer.h */,
-				0B8022E418A2F27600AF845E /* LBContainer.m */,
 				0B78685F189B1C0700AB6782 /* LBFile.h */,
 				0B786865189B1C3300AB6782 /* LBFile.m */,
+				0B8022DE18A2F1BA00AF845E /* LBContainer.h */,
+				0B8022E418A2F27600AF845E /* LBContainer.m */,
 			);
 			path = LoopBack;
 			sourceTree = "<group>";
@@ -461,20 +505,20 @@
 		B3D2211117722AE800B7CB63 /* LoopBackTests */ = {
 			isa = PBXGroup;
 			children = (
-				4769FF07184D6F4F00E5152C /* LBInstallationTests.h */,
-				4769FF08184D6F4F00E5152C /* LBInstallationTests.m */,
 				B3D2211217722AE800B7CB63 /* Supporting Files */,
-				0B3A200D18A55B5A006772C8 /* LBContainerTests.h */,
-				0B3A201518A56BA5006772C8 /* LBContainerTests.m */,
-				0B3A201C18A58586006772C8 /* LBFileTests.h */,
-				0B3A201A18A5856F006772C8 /* LBFileTests.m */,
+				89D3C9511AB17258005A1B90 /* server */,
 				B3D2213917722BAB00B7CB63 /* LBModelTests.h */,
 				B3D2213A17722BAB00B7CB63 /* LBModelTests.m */,
 				B3D2214017725A7F00B7CB63 /* LBModelSubclassingTests.h */,
 				B3D2214117725A7F00B7CB63 /* LBModelSubclassingTests.m */,
+				4769FF07184D6F4F00E5152C /* LBInstallationTests.h */,
+				4769FF08184D6F4F00E5152C /* LBInstallationTests.m */,
 				0B3A201918A57D55006772C8 /* LBUserTests.h */,
 				0B3A201718A57CCD006772C8 /* LBUserTests.m */,
-				89CAC10A1A8E273200FF028D /* LBRESTAdapterTests.m */,
+				0B3A201C18A58586006772C8 /* LBFileTests.h */,
+				0B3A201A18A5856F006772C8 /* LBFileTests.m */,
+				0B3A200D18A55B5A006772C8 /* LBContainerTests.h */,
+				0B3A201518A56BA5006772C8 /* LBContainerTests.m */,
 			);
 			path = LoopBackTests;
 			sourceTree = "<group>";
@@ -545,7 +589,7 @@
 			name = SLRemotingTests;
 			productName = LoopBackTests;
 			productReference = 47D471B7196DF4A1002E2358 /* LoopBackTests copy.octest */;
-			productType = "com.apple.product-type.bundle";
+			productType = "com.apple.product-type.bundle.ocunit-test";
 		};
 		B3D220F617722AE800B7CB63 /* LoopBack */ = {
 			isa = PBXNativeTarget;
@@ -582,7 +626,7 @@
 			name = LoopBackTests;
 			productName = LoopBackTests;
 			productReference = B3D2210817722AE800B7CB63 /* LoopBackTests.octest */;
-			productType = "com.apple.product-type.bundle";
+			productType = "com.apple.product-type.bundle.ocunit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -590,7 +634,7 @@
 		B3D220EF17722AE800B7CB63 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0460;
+				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = StrongLoop;
 			};
 			buildConfigurationList = B3D220F217722AE800B7CB63 /* Build configuration list for PBXProject "LoopBack" */;
@@ -619,8 +663,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				47D471AD196DF4A1002E2358 /* InfoPlist.strings in Resources */,
 				47D471AF196DF4A1002E2358 /* SLRemotingTests-Info.plist in Resources */,
+				89D3DB0F1AB174F1005A1B90 /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -628,14 +672,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				47C48BCD1962123900995044 /* .gitignore in Resources */,
 				0B3A200E18A55B5A006772C8 /* LBContainerTests.h in Resources */,
-				47C48BCC1962123900995044 /* InfoPlist.strings in Resources */,
+				89D3DB0E1AB174F1005A1B90 /* InfoPlist.strings in Resources */,
 				B3D2211617722AE800B7CB63 /* InfoPlist.strings in Resources */,
 				47C48BD81962123900995044 /* SLRemotingTests-Info.plist in Resources */,
-				47C48BD31962123900995044 /* certificate.pem in Resources */,
-				47C48BD21962123900995044 /* package.json in Resources */,
-				47C48BD41962123900995044 /* privatekey.pem in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -715,7 +755,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				47D47194196DF4A1002E2358 /* SLRESTAdapterTests.m in Sources */,
-				47D47195196DF4A1002E2358 /* index.js in Sources */,
 				47D47196196DF4A1002E2358 /* LBModelTests.m in Sources */,
 				47D47197196DF4A1002E2358 /* SLRESTContractTests.m in Sources */,
 				47D47198196DF4A1002E2358 /* LBContainerTests.m in Sources */,
@@ -723,15 +762,8 @@
 				47D4719A196DF4A1002E2358 /* SLRESTAdapterSSLTests.m in Sources */,
 				47D4719B196DF4A1002E2358 /* SLRESTAdapterNonRootTests.m in Sources */,
 				47D4719C196DF4A1002E2358 /* LBModelSubclassingTests.m in Sources */,
-				89CAC10C1A8E273200FF028D /* LBRESTAdapterTests.m in Sources */,
-				47D4719D196DF4A1002E2358 /* contract.js in Sources */,
-				47D4719E196DF4A1002E2358 /* nonroot.js in Sources */,
 				47D4719F196DF4A1002E2358 /* LBInstallationTests.m in Sources */,
 				47D471A0196DF4A1002E2358 /* LBFileTests.m in Sources */,
-				47D471A1196DF4A1002E2358 /* simple-class.js in Sources */,
-				47D471A2196DF4A1002E2358 /* simple.js in Sources */,
-				47D471A3196DF4A1002E2358 /* ssl-config.js in Sources */,
-				47D471A4196DF4A1002E2358 /* contract-class.js in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -769,7 +801,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				47C48BDB1962123900995044 /* SLRESTAdapterTests.m in Sources */,
-				47C48BD01962123900995044 /* index.js in Sources */,
 				B3D2213B17722BAB00B7CB63 /* LBModelTests.m in Sources */,
 				47C48BDC1962123900995044 /* SLRESTContractTests.m in Sources */,
 				0B3A201618A56BA5006772C8 /* LBContainerTests.m in Sources */,
@@ -777,15 +808,8 @@
 				47C48BDA1962123900995044 /* SLRESTAdapterSSLTests.m in Sources */,
 				47C48BD91962123900995044 /* SLRESTAdapterNonRootTests.m in Sources */,
 				B3D2214217725A7F00B7CB63 /* LBModelSubclassingTests.m in Sources */,
-				89CAC10B1A8E273200FF028D /* LBRESTAdapterTests.m in Sources */,
-				47C48BCF1962123900995044 /* contract.js in Sources */,
-				47C48BD11962123900995044 /* nonroot.js in Sources */,
 				4769FF09184D6F4F00E5152C /* LBInstallationTests.m in Sources */,
 				0B3A201B18A5856F006772C8 /* LBFileTests.m in Sources */,
-				47C48BD51962123900995044 /* simple-class.js in Sources */,
-				47C48BD61962123900995044 /* simple.js in Sources */,
-				47C48BD71962123900995044 /* ssl-config.js in Sources */,
-				47C48BCE1962123900995044 /* contract-class.js in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -873,10 +897,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					i386,
-					"$(ARCHS_STANDARD_INCLUDING_64_BIT)",
-				);
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -898,7 +918,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -907,10 +927,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					i386,
-					"$(ARCHS_STANDARD_INCLUDING_64_BIT)",
-				);
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/LoopBack.xcodeproj/xcshareddata/xcschemes/LoopBack.xcscheme
+++ b/LoopBack.xcodeproj/xcshareddata/xcschemes/LoopBack.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0500"
+   LastUpgradeVersion = "0610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -49,6 +49,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B3D220F617722AE800B7CB63"
+            BuildableName = "libLoopBack.a"
+            BlueprintName = "LoopBack"
+            ReferencedContainer = "container:LoopBack.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/LoopBack.xcodeproj/xcshareddata/xcschemes/LoopBackDocs.xcscheme
+++ b/LoopBack.xcodeproj/xcshareddata/xcschemes/LoopBackDocs.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0500"
+   LastUpgradeVersion = "0610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -39,6 +39,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B3F2EADD17AB214A00B52BBE"
+            BuildableName = "LoopBackDocs"
+            BlueprintName = "LoopBackDocs"
+            ReferencedContainer = "container:LoopBack.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/LoopBack.xcodeproj/xcshareddata/xcschemes/LoopBackFramework.xcscheme
+++ b/LoopBack.xcodeproj/xcshareddata/xcschemes/LoopBackFramework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0500"
+   LastUpgradeVersion = "0610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -39,6 +39,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B3DFA5B117970B1200F656D7"
+            BuildableName = "LoopBackFramework"
+            BlueprintName = "LoopBackFramework"
+            ReferencedContainer = "container:LoopBack.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/LoopBack/LBFile.m
+++ b/LoopBack/LBFile.m
@@ -7,13 +7,41 @@
 
 #import "LBFile.h"
 #import "LBRESTAdapter.h"
+#import "SLStreamParam.h"
+
+static NSString *mimeTypeForFileName(NSString *fileName) {
+    CFStringRef pathExtension = (__bridge_retained CFStringRef)[fileName pathExtension];
+    CFStringRef type = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension,
+                                                             pathExtension,
+                                                             NULL);
+    CFRelease(pathExtension);
+    NSString *mimeType =
+        (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass(type, kUTTagClassMIMEType);
+
+    return (mimeType != nil) ? mimeType : @"application/octet-stream";
+}
 
 @implementation LBFile
 
 - (void)uploadWithSuccess:(LBFileUploadSuccessBlock)success
                   failure:(SLFailureBlock)failure {
+
+    NSString *fullLocalPath = [self.localPath stringByAppendingPathComponent:self.name];
+    NSInputStream *inputStream = [NSInputStream inputStreamWithFileAtPath:fullLocalPath];
+    NSString *mimeType = mimeTypeForFileName(self.name);
+    NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:fullLocalPath
+                                                                                error:NULL];
+    NSInteger length = attributes.fileSize;
+
+    __block SLStreamParam *streamParam = [SLStreamParam streamParamWithInputStream:inputStream
+                                                                          fileName:self.name
+                                                                       contentType:mimeType
+                                                                            length:length];
+
    [self invokeMethod:@"upload"
-           parameters:[self toDictionary]
+           parameters:@{@"container": self.container,
+                        @"name": self.name,
+                        @"file": streamParam}
               success:^(id value) {
                   success();
               }
@@ -22,12 +50,18 @@
 
 - (void)downloadWithSuccess:(LBFileDownloadSuccessBlock)success
                     failure:(SLFailureBlock)failure {
-   [self invokeMethod:@"download"
-           parameters:[self toDictionary]
-              success:^(id value) {
-                  success();
-              }
-              failure:failure];
+    NSString *fullLocalPath = [self.localPath stringByAppendingPathComponent:self.name];
+    __block NSOutputStream *outputStream = [NSOutputStream outputStreamToFileAtPath:fullLocalPath
+                                                                             append:NO];
+    
+    [self invokeMethod:@"download"
+            parameters:@{@"container": self.container,
+                         @"name": self.name}
+          outputStream:outputStream
+               success:^(id value) {
+                   success();
+               }
+               failure:failure];
 }
 
 @end
@@ -47,9 +81,8 @@
                                                      verb:@"POST"
                                                 multipart:YES]
             forMethod:[NSString stringWithFormat:@"%@.prototype.upload", self.className]];
-    [contract addItem:[SLRESTContractItem itemWithPattern:[NSString stringWithFormat:@"/%@/:container/download", self.className]
-                                                     verb:@"GET"
-                                                multipart:YES]
+    [contract addItem:[SLRESTContractItem itemWithPattern:[NSString stringWithFormat:@"/%@/:container/download/:name", self.className]
+                                                     verb:@"GET"]
             forMethod:[NSString stringWithFormat:@"%@.prototype.download", self.className]];
     [contract addItem:[SLRESTContractItem itemWithPattern:[NSString stringWithFormat:@"/%@/:container/files/:name", self.className]
                                                      verb:@"GET"]

--- a/LoopBack/LoopBack-Prefix.pch
+++ b/LoopBack/LoopBack-Prefix.pch
@@ -3,5 +3,6 @@
 //
 
 #ifdef __OBJC__
-    #import <Foundation/Foundation.h>
+    #import <MobileCoreServices/MobileCoreServices.h>
+    #import <SystemConfiguration/SystemConfiguration.h>
 #endif

--- a/LoopBackTests/LBFileTests.m
+++ b/LoopBackTests/LBFileTests.m
@@ -92,8 +92,12 @@
         STAssertEqualObjects(file.name, @"uploadTest.txt", @"Invalid name");
         [file downloadWithSuccess:^(void) {
             STAssertTrue([fileManager fileExistsAtPath:fullPath], @"File missing.");
+            NSString *fileContents = [NSString stringWithContentsOfFile:fullPath
+                                                               encoding:NSUTF8StringEncoding
+                                                                  error:nil];
+            STAssertEqualObjects(fileContents, @"Upload test", @"File corrupted");
+            ASYNC_TEST_SIGNAL
         } failure:ASYNC_TEST_FAILURE_BLOCK];
-        ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
 }

--- a/LoopBackTests/server/index.js
+++ b/LoopBackTests/server/index.js
@@ -77,4 +77,6 @@ loopback.autoAttach();
 app.enableAuth();
 app.use(loopback.token({ model: app.models.AccessToken }));
 app.use(loopback.rest());
-app.listen(3000);
+app.listen(3000, function() {
+  console.log('https server is ready at https://localhost:3000.');
+});

--- a/SLRemoting/SLAdapter.h
+++ b/SLRemoting/SLAdapter.h
@@ -123,6 +123,28 @@ extern NSString *SLAdapterNotConnectedErrorDescription;
                    failure:(SLFailureBlock)failure;
 
 /**
+ * Invokes a remotable method exposed statically on the server.
+ *
+ * Unlike SLAdapter::invokeInstanceMethod:constructorParameters:parameters:success:failure:,
+ * no object needs to be created on the server.
+ *
+ * @param method        The method to invoke, e.g. `module.doSomething`.
+ * @param parameters    The parameters to invoke with.
+ * @param outputStream  The stream to which all the response data goes.
+ *                      If this is set, no data is routed for further
+ *                      processing and the success block is invoked with `nil`.
+ * @param success       An SLSuccessBlock to be executed when the invocation
+ *                      succeeds.
+ * @param failure       An SLFailureBlock to be executed when the invocation
+ *                      fails.
+ */
+- (void)invokeStaticMethod:(NSString *)method
+                parameters:(NSDictionary *)parameters
+              outputStream:(NSOutputStream *)outputStream
+                   success:(SLSuccessBlock)success
+                   failure:(SLFailureBlock)failure;
+
+/**
  * Invokes a remotable method exposed within a prototype on the server.
  *
  * This should be thought of as a two-step process. First, the server loads or
@@ -144,6 +166,36 @@ extern NSString *SLAdapterNotConnectedErrorDescription;
 - (void)invokeInstanceMethod:(NSString *)method
        constructorParameters:(NSDictionary *)constructorParameters
                   parameters:(NSDictionary *)parameters
+                     success:(SLSuccessBlock)success
+                     failure:(SLFailureBlock)failure;
+
+/**
+ * Invokes a remotable method exposed within a prototype on the server.
+ *
+ * This should be thought of as a two-step process. First, the server loads or
+ * creates an object with the appropriate type. Then and only then is the method
+ * invoked on that object. The two parameter dictionaries correspond to these
+ * two steps: `creationParameters` for the former, and `parameters` for the
+ * latter.
+ *
+ * @param method                 The method to invoke, e.g.
+ *                               `MyClass.prototype.doSomething`.
+ * @param constructorParameters  The parameters the virual object should be
+ *                               created with.
+ * @param parameters             The parameters to invoke with.
+ * @param outputStream           The stream to which all the response data goes.
+ *                               If this is set, no data is routed for further
+ *                               processing and the success block is invoked
+ *                               with `nil`.
+ * @param success                An SLSuccessBlock to be executed when the
+ *                               invocation succeeds.
+ * @param failure                An SLFailureBlock to be executed when the
+ *                               invocation fails.
+ */
+- (void)invokeInstanceMethod:(NSString *)method
+       constructorParameters:(NSDictionary *)constructorParameters
+                  parameters:(NSDictionary *)parameters
+                outputStream:(NSOutputStream *)outputStream
                      success:(SLSuccessBlock)success
                      failure:(SLFailureBlock)failure;
 

--- a/SLRemoting/SLAdapter.m
+++ b/SLRemoting/SLAdapter.m
@@ -65,9 +65,26 @@ NSString *SLAdapterNotConnectedErrorDescription = @"Adapter not connected.";
     NSAssert(NO, @"Invalid Adapter.");
 }
 
+- (void)invokeStaticMethod:(NSString *)path
+                parameters:(NSDictionary *)parameters
+              outputStream:(NSOutputStream *)outputStream
+                   success:(SLSuccessBlock)success
+                   failure:(SLFailureBlock)failure {
+    NSAssert(NO, @"Invalid Adapter.");
+}
+
 - (void)invokeInstanceMethod:(NSString *)path
        constructorParameters:(NSDictionary *)constructorParameters
                   parameters:(NSDictionary *)parameters
+                     success:(SLSuccessBlock)success
+                     failure:(SLFailureBlock)failure {
+    NSAssert(NO, @"Invalid Adapter.");
+}
+
+- (void)invokeInstanceMethod:(NSString *)method
+       constructorParameters:(NSDictionary *)constructorParameters
+                  parameters:(NSDictionary *)parameters
+                outputStream:(NSOutputStream *)outputStream
                      success:(SLSuccessBlock)success
                      failure:(SLFailureBlock)failure {
     NSAssert(NO, @"Invalid Adapter.");

--- a/SLRemoting/SLObject.h
+++ b/SLRemoting/SLObject.h
@@ -72,6 +72,27 @@ extern NSString *SLObjectInvalidRepositoryDescription;
              success:(SLSuccessBlock)success
              failure:(SLFailureBlock)failure;
 
+/**
+ * Invokes a remotable method exposed within instances of this class on the
+ * server.
+ *
+ * @see SLAdapter::invokeInstanceMethod:constructorParameters:parameters:outputStream:success:failure:
+ *
+ * @param name          The method to invoke (without the prototype), e.g.
+ *                      `doSomething`.
+ * @param parameters    The parameters to invoke with.
+ * @param outputStream  The stream to which all the response data goes.
+ * @param success       An SLSuccessBlock to be executed when the invocation
+ *                      succeeds.
+ * @param failure       An SLFailureBlock to be executed when the invocation
+ *                      fails.
+ */
+- (void)invokeMethod:(NSString *)name
+          parameters:(NSDictionary *)parameters
+        outputStream:(NSOutputStream *)outputStream
+             success:(SLSuccessBlock)success
+             failure:(SLFailureBlock)failure;
+
 @end
 
 /**

--- a/SLRemoting/SLObject.m
+++ b/SLRemoting/SLObject.m
@@ -58,6 +58,26 @@ NSString *SLObjectInvalidRepositoryDescription = @"Invalid repository.";
                                          failure:failure];
 }
 
+- (void)invokeMethod:(NSString *)name
+          parameters:(NSDictionary *)parameters
+        outputStream:(NSOutputStream *)outputStream
+             success:(SLSuccessBlock)success
+             failure:(SLFailureBlock)failure {
+
+    NSAssert(self.repository, SLObjectInvalidRepositoryDescription);
+
+    NSString *path = [NSString stringWithFormat:@"%@.prototype.%@",
+                      self.repository.className,
+                      name];
+
+    [self.repository.adapter invokeInstanceMethod:path
+                            constructorParameters:self.creationParameters
+                                       parameters:parameters
+                                     outputStream:outputStream
+                                          success:success
+                                          failure:failure];
+}
+
 @end
 
 @implementation SLRepository

--- a/SLRemoting/SLRESTAdapter.m
+++ b/SLRemoting/SLRESTAdapter.m
@@ -35,6 +35,8 @@ static NSString * const DEFAULT_DEV_BASE_URL = @"http://localhost:3001";
 
 @implementation SLRESTAdapter
 
+@synthesize connected;
+
 - (instancetype)initWithURL:(NSURL *)url allowsInvalidSSLCertificate : (BOOL) allowsInvalidSSLCertificate {
     self = [super initWithURL:url allowsInvalidSSLCertificate:allowsInvalidSSLCertificate];
 

--- a/SLRemoting/SLRESTAdapter.m
+++ b/SLRemoting/SLRESTAdapter.m
@@ -6,6 +6,7 @@
  */
 
 #import "SLRESTAdapter.h"
+#import "SLStreamParam.h"
 
 #import "SLAFHTTPClient.h"
 #import "SLAFJSONRequestOperation.h"
@@ -18,18 +19,16 @@ static NSString * const DEFAULT_DEV_BASE_URL = @"http://localhost:3001";
 
 @property (readwrite, nonatomic) BOOL connected;
 
-- (void)requestPath:(NSString *)path
-               verb:(NSString *)verb
-         parameters:(NSDictionary *)parameters
-            success:(SLSuccessBlock)success
-            failure:(SLFailureBlock)failure;
+- (void)requestWithPath:(NSString *)path
+                   verb:(NSString *)verb
+             parameters:(NSDictionary *)parameters
+              multipart:(BOOL)multipart
+           outputStream:(NSOutputStream *)outputStream
+                success:(SLSuccessBlock)success
+                failure:(SLFailureBlock)failure;
 
-- (void)requestMultipartPath:(NSString *)path
-                        verb:(NSString *)verb
-                    fileName:(NSString *)fileName
-                    localURL:(NSString *)localURL
-                     success:(SLSuccessBlock)success
-                     failure:(SLFailureBlock)failure;
+- (void)appendPartToMultiPartForm:(id <AFMultipartFormData>)formData
+                   withParameters:(NSDictionary *)parameters;
 
 @end
 
@@ -67,21 +66,53 @@ static NSString * const DEFAULT_DEV_BASE_URL = @"http://localhost:3001";
                 parameters:(NSDictionary *)parameters
                    success:(SLSuccessBlock)success
                    failure:(SLFailureBlock)failure {
+
+    [self invokeStaticMethod:method
+                  parameters:parameters
+                outputStream:nil
+                     success:success
+                     failure:failure];
+}
+
+- (void)invokeStaticMethod:(NSString *)method
+                parameters:(NSDictionary *)parameters
+              outputStream:(NSOutputStream *)outputStream
+                   success:(SLSuccessBlock)success
+                   failure:(SLFailureBlock)failure {
+    
     NSAssert(self.contract, @"Invalid contract.");
 
     NSString *verb = [self.contract verbForMethod:method];
     NSString *path = [self.contract urlForMethod:method parameters:parameters];
+    BOOL multipart = [self.contract multipartForMethod:method];
 
-    [self requestPath:path
-                 verb:verb
-           parameters:parameters
-              success:success
-              failure:failure];
+    [self requestWithPath:path
+                     verb:verb
+               parameters:parameters
+                multipart:multipart
+             outputStream:outputStream
+                  success:success
+                  failure:failure];
 }
 
 - (void)invokeInstanceMethod:(NSString *)method
        constructorParameters:(NSDictionary *)constructorParameters
                   parameters:(NSDictionary *)parameters
+                     success:(SLSuccessBlock)success
+                     failure:(SLFailureBlock)failure {
+
+    [self invokeInstanceMethod:method
+         constructorParameters:constructorParameters
+                    parameters:parameters
+                  outputStream:nil
+                       success:success
+                       failure:failure];
+}
+
+- (void)invokeInstanceMethod:(NSString *)method
+       constructorParameters:(NSDictionary *)constructorParameters
+                  parameters:(NSDictionary *)parameters
+                outputStream:(NSOutputStream *)outputStream
                      success:(SLSuccessBlock)success
                      failure:(SLFailureBlock)failure {
     // TODO(schoon) - Break out and document error description.
@@ -93,28 +124,25 @@ static NSString * const DEFAULT_DEV_BASE_URL = @"http://localhost:3001";
 
     NSString *verb = [self.contract verbForMethod:method];
     NSString *path = [self.contract urlForMethod:method parameters:combinedParameters];
+    BOOL multipart = [self.contract multipartForMethod:method];
 
-    if ([self.contract multipartForMethod:method]) {
-        [self requestMultipartPath:path
-                              verb:verb
-                          fileName:parameters[@"name"]
-                          localURL:parameters[@"localPath"]
-                           success:success
-                           failure:failure];
-    } else {
-        [self requestPath:path
+    [self requestWithPath:path
                      verb:verb
                parameters:combinedParameters
+                multipart:multipart
+             outputStream:outputStream
                   success:success
                   failure:failure];
-    }
 }
 
-- (void)requestPath:(NSString *)path
-               verb:(NSString *)verb
-         parameters:(NSDictionary *)parameters
-            success:(SLSuccessBlock)success
-            failure:(SLFailureBlock)failure {
+- (void)requestWithPath:(NSString *)path
+                   verb:(NSString *)verb
+             parameters:(NSDictionary *)parameters
+              multipart:(BOOL)multipart
+           outputStream:(NSOutputStream *)outputStream
+                success:(SLSuccessBlock)success
+                failure:(SLFailureBlock)failure {
+
     NSAssert(self.connected, SLAdapterNotConnectedErrorDescription);
 
     if ([[verb uppercaseString] isEqualToString:@"GET"]) {
@@ -127,58 +155,66 @@ static NSString * const DEFAULT_DEV_BASE_URL = @"http://localhost:3001";
     if ([path hasPrefix:@"/"]) {
         path = [path substringFromIndex:1];
     }
-    
-	NSURLRequest *request = [client requestWithMethod:verb path:path parameters:parameters];
-    SLAFHTTPRequestOperation *operation = [client HTTPRequestOperationWithRequest:request success:^(SLAFHTTPRequestOperation *operation, id responseObject) {
-        success(responseObject);
-    } failure:^(SLAFHTTPRequestOperation *operation, NSError *error) {
-        failure(error);
-    }];
+
+    NSURLRequest *request;
+
+    if (!multipart) {
+        request = [client requestWithMethod:verb path:path parameters:parameters];
+    } else {
+        request = [client multipartFormRequestWithMethod:verb
+                                                    path:path
+                                              parameters:parameters
+                               constructingBodyWithBlock: ^(id <AFMultipartFormData>formData) {
+                                   [self appendPartToMultiPartForm:formData
+                                                    withParameters:parameters];
+                               }];
+    }
+
+    SLAFHTTPRequestOperation *operation;
+    // Synchronize the block so that the invocations of client's [un]registerHTTPOperationClass:
+    // and HTTPRequestOperationWithRequest:success: methods become atomic.
+    @synchronized(self) {
+        if (outputStream != nil) {
+            // The following is needed to force the received binary payload always go to the stream
+            [client unregisterHTTPOperationClass:[SLAFJSONRequestOperation class]];
+        }
+
+        operation = [client HTTPRequestOperationWithRequest:request
+                                                    success:^(SLAFHTTPRequestOperation *operation,
+                                                              id responseObject) {
+            success(responseObject);
+        } failure:^(SLAFHTTPRequestOperation *operation, NSError *error) {
+            failure(error);
+        }];
+
+        if (outputStream != nil) {
+            // Re-register the response handler class
+            [client registerHTTPOperationClass:[SLAFJSONRequestOperation class]];
+            
+            operation.outputStream = outputStream;
+        }
+    }
+
     [client enqueueHTTPRequestOperation:operation];
 }
 
-- (void)requestMultipartPath:(NSString *)path
-                        verb:(NSString *)verb
-                    fileName:(NSString *)fileName
-                    localURL:(NSString *)localURL
-                     success:(SLSuccessBlock)success
-                     failure:(SLFailureBlock)failure {
-    NSAssert(self.connected, SLAdapterNotConnectedErrorDescription);
-    
-    // Remove the leading / so that the path is treated as relative to the baseURL
-    if ([path hasPrefix:@"/"]) {
-        path = [path substringFromIndex:1];
+- (void)appendPartToMultiPartForm:(id <AFMultipartFormData>)formData
+                   withParameters:(NSDictionary *)parameters {
+    for (id key in parameters) {
+        id value = parameters[key];
+
+        if ([value isKindOfClass:[SLStreamParam class]]) {
+            SLStreamParam *streamParam = (SLStreamParam *)value;
+            [formData appendPartWithInputStream:streamParam.inputStream
+                                           name:key
+                                       fileName:streamParam.fileName
+                                         length:streamParam.length
+                                       mimeType:streamParam.contentType];
+        } else {
+            NSLog(@"%s: Ignored non SLStreamParam parameter %@ specified for multipart form",
+                  __FUNCTION__, [value class]);
+        }
     }
-    
-    NSURLRequest *request;
-    NSOutputStream *outStream = nil;
-    if ([[verb uppercaseString] isEqualToString:@"GET"]) {
-        path = [path stringByAppendingPathComponent:fileName];
-        
-        request = [client requestWithMethod:verb path:path parameters:nil];
-        outStream = [NSOutputStream outputStreamToFileAtPath:[localURL stringByAppendingPathComponent:fileName] append:NO];
-    } else {
-        request = [client multipartFormRequestWithMethod:verb path:path parameters:nil constructingBodyWithBlock: ^(id <AFMultipartFormData>formData) {
-            NSString* fullLocalPath = [localURL stringByAppendingPathComponent:fileName];
-            NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:fullLocalPath error:NULL];
-            [formData appendPartWithInputStream:[[NSInputStream alloc] initWithFileAtPath:fullLocalPath]
-                                           name:@"uploadfiles"
-                                       fileName:fileName
-                                         length:attributes.fileSize
-                                       mimeType:@"multipart/form-data"];
-        }];
-    }
-    
-    SLAFHTTPRequestOperation *operation = [client HTTPRequestOperationWithRequest:request success:^(SLAFHTTPRequestOperation *operation, id responseObject) {
-        success(responseObject);
-    } failure:^(SLAFHTTPRequestOperation *operation, NSError *error) {
-        failure(error);
-    }];
-    if (outStream != nil) {
-        operation.outputStream = outStream;
-    }
-    
-    [client enqueueHTTPRequestOperation:operation];
 }
 
 - (NSString*)accessToken

--- a/SLRemoting/SLRESTContract.h
+++ b/SLRemoting/SLRESTContract.h
@@ -32,14 +32,6 @@ extern NSString *SLRESTContractDefaultVerb;
 + (instancetype)itemWithPattern:(NSString *)pattern;
 
 /**
- * Initializes a new item to encapsulate the given pattern.
- *
- * @param  pattern  The pattern to represent.
- * @return          The item.
- */
-- (instancetype)initWithPattern:(NSString *)pattern;
-
-/**
  * Returns a new item encapsulating the given pattern and verb.
  *
  * @param  pattern  The pattern to represent.
@@ -47,15 +39,6 @@ extern NSString *SLRESTContractDefaultVerb;
  * @return          A new item.
  */
 + (instancetype)itemWithPattern:(NSString *)pattern verb:(NSString *)verb;
-
-/**
- * Initializes a new item encapsulating the given pattern and verb.
- *
- * @param  pattern  The pattern to represent.
- * @param  verb     The verb to represent.
- * @return          A new item.
- */
-- (instancetype)initWithPattern:(NSString *)pattern verb:(NSString *)verb;
 
 /**
  * Returns a new item encapsulating the given pattern, verb and multipart setting.
@@ -66,16 +49,6 @@ extern NSString *SLRESTContractDefaultVerb;
  * @return           A new item.
  */
 + (instancetype)itemWithPattern:(NSString *)pattern verb:(NSString *)verb multipart:(BOOL)multipart;
-
-/**
- * Initializes a new item encapsulating the given pattern and verb.
- *
- * @param  pattern   The pattern to represent.
- * @param  verb      The verb to represent.
- * @param multiplart Indicates this item is a multipart mime type.
- * @return           A new item.
- */
-- (instancetype)initWithPattern:(NSString *)pattern verb:(NSString *)verb multipart:(BOOL)multipart;
 
 @end
 

--- a/SLRemoting/SLRESTContract.m
+++ b/SLRemoting/SLRESTContract.m
@@ -14,6 +14,34 @@ NSString *SLRESTContractDefaultVerb = @"POST";
 @property (readwrite, nonatomic, copy) NSString *pattern;
 @property (readwrite, nonatomic, copy) NSString *verb;
 @property (readwrite, nonatomic, assign) BOOL multipart;
+@property (readwrite, nonatomic, assign) BOOL binaryCallback;
+
+/**
+ * Initializes a new item to encapsulate the given pattern.
+ *
+ * @param  pattern  The pattern to represent.
+ * @return          The item.
+ */
+- (instancetype)initWithPattern:(NSString *)pattern;
+
+/**
+ * Initializes a new item encapsulating the given pattern and verb.
+ *
+ * @param  pattern  The pattern to represent.
+ * @param  verb     The verb to represent.
+ * @return          A new item.
+ */
+- (instancetype)initWithPattern:(NSString *)pattern verb:(NSString *)verb;
+
+/**
+ * Initializes a new item encapsulating the given pattern, verb and multipart setting.
+ *
+ * @param  pattern   The pattern to represent.
+ * @param  verb      The verb to represent.
+ * @param multiplart Indicates this item is a multipart mime type.
+ * @return           A new item.
+ */
+- (instancetype)initWithPattern:(NSString *)pattern verb:(NSString *)verb multipart:(BOOL)multipart;
 
 @end
 

--- a/SLRemoting/SLStreamParam.h
+++ b/SLRemoting/SLStreamParam.h
@@ -1,0 +1,24 @@
+/**
+ * @file SLStreamParam.h
+ *
+ * @copyright (c) 2015 StrongLoop. All rights reserved.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ * A request parameter that is a (binary) stream.
+ */
+@interface SLStreamParam : NSObject
+
+@property (readonly, nonatomic, strong) NSInputStream *inputStream;
+@property (readonly, nonatomic, copy) NSString *fileName;
+@property (readonly, nonatomic, copy) NSString *contentType;
+@property (readonly, nonatomic, assign) NSInteger length;
+
++ (instancetype)streamParamWithInputStream:(NSInputStream *)inputStream
+                                  fileName:(NSString *)fileName
+                               contentType:(NSString *)contentType
+                                    length:(NSInteger)length;
+
+@end

--- a/SLRemoting/SLStreamParam.m
+++ b/SLRemoting/SLStreamParam.m
@@ -1,0 +1,34 @@
+/**
+ * @file SLStreamParam.m
+ *
+ * @copyright (c) 2015 StrongLoop. All rights reserved.
+ */
+
+#import "SLStreamParam.h"
+
+@interface SLStreamParam()
+
+@property (readwrite, nonatomic, strong) NSInputStream *inputStream;
+@property (readwrite, nonatomic, copy) NSString *fileName;
+@property (readwrite, nonatomic, copy) NSString *contentType;
+@property (readwrite, nonatomic, assign) NSInteger length;
+
+@end
+
+@implementation SLStreamParam
+
++ (instancetype)streamParamWithInputStream:(NSInputStream *)inputStream
+                                  fileName:(NSString *)fileName
+                               contentType:(NSString *)contentType
+                                    length:(NSInteger)length {
+
+    SLStreamParam *param = [[self alloc] init];
+    param.inputStream = inputStream;
+    param.fileName = fileName;
+    param.contentType = contentType;
+    param.length = length;
+
+    return param;
+}
+
+@end

--- a/SLRemotingTests/SLRESTAdapterTests.m
+++ b/SLRemotingTests/SLRESTAdapterTests.m
@@ -129,4 +129,43 @@
     ASYNC_TEST_END
 }
 
+- (void)testBinaryPayloadStatic {
+    __block NSOutputStream *outputStream = [NSOutputStream outputStreamToMemory];
+
+    ASYNC_TEST_START
+    [adapter invokeStaticMethod:@"SimpleClass.binary"
+                     parameters:nil
+                   outputStream:outputStream
+                        success:^(id value) {
+                            NSData *data =
+                                [outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
+                            const unsigned char *bytes = [data bytes];
+                            STAssertTrue(bytes[0] == 1 && bytes[1] == 2 && bytes[2] == 3,
+                                         @"Incorrect binary data returned.");
+                            ASYNC_TEST_SIGNAL
+                        }
+                        failure:ASYNC_TEST_FAILURE_BLOCK];
+    ASYNC_TEST_END
+}
+
+- (void)testBinaryPayload {
+    __block NSOutputStream *outputStream = [NSOutputStream outputStreamToMemory];
+
+    ASYNC_TEST_START
+    [adapter invokeInstanceMethod:@"SimpleClass.prototype.binary"
+            constructorParameters:nil
+                       parameters:nil
+                     outputStream:outputStream
+                          success:^(id value) {
+                              NSData *data =
+                                [outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
+                              const unsigned char *bytes = [data bytes];
+                              STAssertTrue(bytes[0] == 4 && bytes[1] == 5 && bytes[2] == 6,
+                                           @"Incorrect binary data returned.");
+                              ASYNC_TEST_SIGNAL
+                          }
+                          failure:ASYNC_TEST_FAILURE_BLOCK];
+    ASYNC_TEST_END
+}
+
 @end

--- a/SLRemotingTests/SLRESTContractTests.m
+++ b/SLRemotingTests/SLRESTContractTests.m
@@ -9,6 +9,7 @@
 #import "SLRESTContractTests.h"
 
 #import "SLRESTAdapter.h"
+#import "SLStreamParam.h"
 #import "SLObject.h"
 
 static NSString * const SERVER_URL = @"http://localhost:3001";

--- a/SLRemotingTests/server/contract.js
+++ b/SLRemotingTests/server/contract.js
@@ -20,10 +20,12 @@ transform.accepts = [{ arg: 'str', type: 'string' }];
 transform.returns = [{ arg: 'data', type: 'string' }];
 transform.http = { path: '/customizedTransform', verb: 'GET' };
 
-function getAuthorizationHeader(auth, cb) {
-  cb(null, auth);
+/**
+ * Obtains the access token and returns it.
+ */
+function getAuthorizationHeader(auth, callback) {
+  callback(null, auth);
 }
-
 getAuthorizationHeader.shared = true;
 getAuthorizationHeader.accepts = [{ arg: 'auth', type: 'string', http: function(ctx) {
   return ctx.req.header('authorization');
@@ -34,5 +36,5 @@ getAuthorizationHeader.http = { path: '/get-auth' };
 module.exports = {
   getSecret: getSecret,
   transform: transform,
-  getAuthorizationHeader: getAuthorizationHeader
+  getAuthorizationHeader: getAuthorizationHeader,
 };

--- a/SLRemotingTests/server/simple-class.js
+++ b/SLRemotingTests/server/simple-class.js
@@ -45,4 +45,24 @@ SimpleClass.getFavoritePerson.shared = true;
 SimpleClass.getFavoritePerson.accepts = [];
 SimpleClass.getFavoritePerson.returns = [{ arg: 'data', type: 'string' }];
 
+/**
+ * Returns a binary sequence.
+ */
+SimpleClass.binary = function(res) {
+  res.type('application/octet-stream');
+  res.send(200, new Buffer('010203', 'hex'));
+};
+SimpleClass.binary.shared = true;
+SimpleClass.binary.accepts = [{arg: 'res', type: 'object', 'http': {source: 'res'}}];
+
+/**
+ * Returns a binary sequence.
+ */
+SimpleClass.prototype.binary = function(res) {
+  res.type('application/octet-stream');
+  res.send(200, new Buffer('040506', 'hex'));
+};
+SimpleClass.prototype.binary.shared = true;
+SimpleClass.prototype.binary.accepts = [{arg: 'res', type: 'object', 'http': {source: 'res'}}];
+
 module.exports = SimpleClass;


### PR DESCRIPTION
LBFile and SLRESTAdapter seemed left in a temporary implementation to get the file upload/download working. (e.g. the contract for file download needed to be "/%@/:container/download" with multipart specified, which should have been "/%@/:container/download/:name" w/o multipart).

In order to support file downloading in an efficient manner, adapter's invoke methods now include the versions that takes an output stream as a parameter.  If a stream is set, the entire response data go into the stream.  It is used for fixing file download implementation in LBFile.  It is also intended to be used for binary payload download to a data buffer in future.

Multipart form handling was made better (it used to be specialized just for the purpose of file uploading).  If multipart is set to YES in the contract, SLRESTAdapter's invoke methods construct each part based on a StreamParam object supplied via the parameters.

Made SLRESTContractItem's instance initialization methods private, as those won't be called directly by developers.

LBFile's API has not been changed (but some changes are under consideration).

@bajtos could you please review?