### PR TITLE
Fix contract mistakes in LBUser -- Fix Issue 26

### DIFF
--- a/LoopBack/LBUser.m
+++ b/LoopBack/LBUser.m
@@ -29,8 +29,10 @@
 
 - (SLRESTContract *)contract {
     SLRESTContract *contract = [super contract];
-    
-    [contract addItem:[SLRESTContractItem itemWithPattern:[NSString stringWithFormat:@"/%@/logout", self.className] verb:@"GET"]
+
+    [contract addItem:[SLRESTContractItem itemWithPattern:[NSString stringWithFormat:@"/%@/login?include=user", self.className] verb:@"POST"]
+            forMethod:[NSString stringWithFormat:@"%@.login", self.className]];
+    [contract addItem:[SLRESTContractItem itemWithPattern:[NSString stringWithFormat:@"/%@/logout", self.className] verb:@"POST"]
             forMethod:[NSString stringWithFormat:@"%@.logout", self.className]];
     
     return contract;

--- a/LoopBackTests/LBUserTests.m
+++ b/LoopBackTests/LBUserTests.m
@@ -94,7 +94,11 @@
     ASYNC_TEST_START
     [self.repository userByLoginWithEmail:@"testUser@test.com" password:@"test" success:^(LBUser* user) {
         [self.repository logoutWithSuccess:^(void) {
-        ASYNC_TEST_SIGNAL
+            // The following second try to logout should fail if the first logout succeeded
+            [self.repository logoutWithSuccess:ASYNC_TEST_FAILURE_BLOCK
+            failure:^(NSError *error) {
+                ASYNC_TEST_SIGNAL
+            }];
         } failure:ASYNC_TEST_FAILURE_BLOCK];
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END

--- a/LoopBackTests/server/package.json
+++ b/LoopBackTests/server/package.json
@@ -4,8 +4,9 @@
   "description": "A test server for running loopback-clients integration testing.",
   "main": "index.js",
   "dependencies": {
-    "loopback": "1.x.x",
-    "loopback-component-push": "~1.2.2",
-    "loopback-component-storage": "~1.0.5"
+    "loopback": "^2.14.0",
+    "loopback-component-push": "^1.4.4",
+    "loopback-component-storage": "^1.3.1",
+    "morgan": "^1.5.2"
   }
 }


### PR DESCRIPTION
- Fix the verb for login method (changed from GET to POST)
- Update test server's package.json to use loopback 2.x instead of 1.x
  (this unveiled the above verb mistake issue)
- Add missing contract configuration for login ("login?include=user")
- Improve [LBUserTest -testLogout] to test if the logout actually took effect

Thank you, @benmarten, for looking into the issue! https://github.com/strongloop/loopback-sdk-ios/issues/26

@bajtos could you please review?