### PR TITLE
Mac osx

### DIFF
--- a/LoopBack.xcodeproj/project.pbxproj
+++ b/LoopBack.xcodeproj/project.pbxproj
@@ -124,6 +124,66 @@
 		B3DFA5AE17970ABD00F656D7 /* LBModel.h in Headers */ = {isa = PBXBuildFile; fileRef = B3D2212217722B1700B7CB63 /* LBModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3DFA5AF17970ABD00F656D7 /* LBRESTAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = B3D221481773766800B7CB63 /* LBRESTAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3DFA5B017970AC700F656D7 /* LoopBack-Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = B3D220FE17722AE800B7CB63 /* LoopBack-Prefix.pch */; };
+		E45123371AE0422A00F0DB30 /* SLStreamParam.m in Sources */ = {isa = PBXBuildFile; fileRef = 8973753D1AB2A60A00FB31A2 /* SLStreamParam.m */; };
+		E4C9BC341AD6F9C800D70046 /* LoopBackOSX.h in Headers */ = {isa = PBXBuildFile; fileRef = E4C9BC331AD6F9C800D70046 /* LoopBackOSX.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC3A1AD6F9C800D70046 /* LoopBack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4C9BC2F1AD6F9C800D70046 /* LoopBack.framework */; };
+		E4C9BC481AD6FAF400D70046 /* SLRESTAdapterNonRootTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC61962123900995044 /* SLRESTAdapterNonRootTests.m */; };
+		E4C9BC491AD6FB3100D70046 /* SLRESTAdapterSSLTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC71962123900995044 /* SLRESTAdapterSSLTests.m */; };
+		E4C9BC4A1AD6FB3900D70046 /* SLRESTAdapterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC91962123900995044 /* SLRESTAdapterTests.m */; };
+		E4C9BC4B1AD6FB3D00D70046 /* SLRESTContractTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BCB1962123900995044 /* SLRESTContractTests.m */; };
+		E4C9BC4C1AD6FB4800D70046 /* SLAFHTTPClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B751962120E00995044 /* SLAFHTTPClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC4D1AD6FB4E00D70046 /* SLAFHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B761962120E00995044 /* SLAFHTTPClient.m */; };
+		E4C9BC4E1AD6FB5300D70046 /* SLAFHTTPRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B771962120E00995044 /* SLAFHTTPRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC4F1AD6FB6E00D70046 /* SLAFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B781962120E00995044 /* SLAFHTTPRequestOperation.m */; };
+		E4C9BC501AD6FB7100D70046 /* SLAFImageRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B791962120E00995044 /* SLAFImageRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC511AD6FB7800D70046 /* SLAFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B7A1962120E00995044 /* SLAFImageRequestOperation.m */; };
+		E4C9BC521AD6FB7F00D70046 /* SLAFJSONRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B7B1962120E00995044 /* SLAFJSONRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC531AD6FB8400D70046 /* SLAFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B7C1962120E00995044 /* SLAFJSONRequestOperation.m */; };
+		E4C9BC541AD6FB8900D70046 /* SLAFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B7D1962120E00995044 /* SLAFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC551AD6FB9200D70046 /* SLAFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B7E1962120E00995044 /* SLAFNetworkActivityIndicatorManager.m */; };
+		E4C9BC561AD6FB9500D70046 /* SLAFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B7F1962120E00995044 /* SLAFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC571AD6FB9A00D70046 /* SLAFPropertyListRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B801962120E00995044 /* SLAFPropertyListRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC581AD6FB9F00D70046 /* SLAFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B811962120E00995044 /* SLAFPropertyListRequestOperation.m */; };
+		E4C9BC591AD6FBA200D70046 /* SLAFURLConnectionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B821962120E00995044 /* SLAFURLConnectionOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC5A1AD6FBA700D70046 /* SLAFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B831962120E00995044 /* SLAFURLConnectionOperation.m */; };
+		E4C9BC5B1AD6FBAA00D70046 /* SLAFXMLRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B841962120E00995044 /* SLAFXMLRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC5C1AD6FBAE00D70046 /* SLAFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B851962120E00995044 /* SLAFXMLRequestOperation.m */; };
+		E4C9BC5D1AD6FBB200D70046 /* UIImageView+SLAFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B861962120E00995044 /* UIImageView+SLAFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC5E1AD6FBB600D70046 /* UIImageView+SLAFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B871962120E00995044 /* UIImageView+SLAFNetworking.m */; };
+		E4C9BC5F1AD6FBBE00D70046 /* SLAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B891962120E00995044 /* SLAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC601AD6FBC200D70046 /* SLAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B8A1962120E00995044 /* SLAdapter.m */; };
+		E4C9BC611AD6FBC500D70046 /* SLObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B8B1962120E00995044 /* SLObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC621AD6FBCA00D70046 /* SLObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B8C1962120E00995044 /* SLObject.m */; };
+		E4C9BC631AD6FBD200D70046 /* SLRemoting-Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B8D1962120E00995044 /* SLRemoting-Prefix.pch */; };
+		E4C9BC641AD6FBD700D70046 /* SLRemoting.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B8E1962120E00995044 /* SLRemoting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC651AD6FBDB00D70046 /* SLRemotingUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B8F1962120E00995044 /* SLRemotingUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC661AD6FBDF00D70046 /* SLRemotingUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B901962120E00995044 /* SLRemotingUtils.m */; };
+		E4C9BC671AD6FBE300D70046 /* SLRESTAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B911962120E00995044 /* SLRESTAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC681AD6FBE700D70046 /* SLRESTAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B921962120E00995044 /* SLRESTAdapter.m */; };
+		E4C9BC691AD6FBEA00D70046 /* SLRESTContract.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C48B931962120E00995044 /* SLRESTContract.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC6A1AD6FBEE00D70046 /* SLRESTContract.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48B941962120E00995044 /* SLRESTContract.m */; };
+		E4C9BC6C1AD6FC0000D70046 /* LBInstallation.h in Headers */ = {isa = PBXBuildFile; fileRef = 47AD031018491DA700F724C8 /* LBInstallation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC6E1AD6FC0800D70046 /* LoopBack.h in Headers */ = {isa = PBXBuildFile; fileRef = B3D220FF17722AE800B7CB63 /* LoopBack.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC6F1AD6FC0F00D70046 /* LoopBack-Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = B3D220FE17722AE800B7CB63 /* LoopBack-Prefix.pch */; };
+		E4C9BC701AD6FC1800D70046 /* LBModel.h in Headers */ = {isa = PBXBuildFile; fileRef = B3D2212217722B1700B7CB63 /* LBModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC721AD6FC1E00D70046 /* LBModel.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2212317722B1700B7CB63 /* LBModel.m */; };
+		E4C9BC731AD6FC2000D70046 /* LBRESTAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = B3D221481773766800B7CB63 /* LBRESTAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC741AD6FC2400D70046 /* LBRESTAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D221491773766800B7CB63 /* LBRESTAdapter.m */; };
+		E4C9BC751AD6FC2700D70046 /* LBUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B6DCCA318806F2E00F7E57A /* LBUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC761AD6FC2B00D70046 /* LBUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B6DCCA418806F2E00F7E57A /* LBUser.m */; };
+		E4C9BC771AD6FC2D00D70046 /* LBAccessToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B4F52A818908089004F675A /* LBAccessToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC781AD6FC3100D70046 /* LBAccessToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B4F52A918908089004F675A /* LBAccessToken.m */; };
+		E4C9BC791AD6FC3400D70046 /* LBContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B8022DE18A2F1BA00AF845E /* LBContainer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC7A1AD6FC5D00D70046 /* LBContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B8022E418A2F27600AF845E /* LBContainer.m */; };
+		E4C9BC7B1AD6FC6100D70046 /* LBFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B78685F189B1C0700AB6782 /* LBFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4C9BC7C1AD6FC6800D70046 /* LBFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B786865189B1C3300AB6782 /* LBFile.m */; };
+		E4C9BC7D1AD6FC7000D70046 /* LBInstallationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4769FF08184D6F4F00E5152C /* LBInstallationTests.m */; };
+		E4C9BC7E1AD6FC9B00D70046 /* LBContainerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A201518A56BA5006772C8 /* LBContainerTests.m */; };
+		E4C9BC7F1AD6FCA300D70046 /* LBFileTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A201A18A5856F006772C8 /* LBFileTests.m */; };
+		E4C9BC801AD6FCA800D70046 /* LBModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2213A17722BAB00B7CB63 /* LBModelTests.m */; };
+		E4C9BC811AD6FCAD00D70046 /* LBModelSubclassingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2214117725A7F00B7CB63 /* LBModelSubclassingTests.m */; };
+		E4C9BC821AD6FCB300D70046 /* LBUserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A201718A57CCD006772C8 /* LBUserTests.m */; };
+		E4C9BC841AD7005E00D70046 /* LBInstallation.m in Sources */ = {isa = PBXBuildFile; fileRef = 47AD031118491DA700F724C8 /* LBInstallation.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -147,6 +207,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = B3D220F617722AE800B7CB63;
 			remoteInfo = LoopBack;
+		};
+		E4C9BC3B1AD6F9C800D70046 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B3D220EF17722AE800B7CB63 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E4C9BC2E1AD6F9C800D70046;
+			remoteInfo = LoopBackOSX;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -250,6 +317,11 @@
 		B3D221481773766800B7CB63 /* LBRESTAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LBRESTAdapter.h; sourceTree = "<group>"; };
 		B3D221491773766800B7CB63 /* LBRESTAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBRESTAdapter.m; sourceTree = "<group>"; };
 		B3DC030C178F1EE20044DD58 /* libobjc.A.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libobjc.A.dylib; path = usr/lib/libobjc.A.dylib; sourceTree = SDKROOT; };
+		E4C9BC2F1AD6F9C800D70046 /* LoopBack.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LoopBack.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E4C9BC321AD6F9C800D70046 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E4C9BC331AD6F9C800D70046 /* LoopBackOSX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoopBackOSX.h; sourceTree = "<group>"; };
+		E4C9BC391AD6F9C800D70046 /* LoopBackOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LoopBackOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E4C9BC3F1AD6F9C800D70046 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -285,6 +357,21 @@
 				895B41821AB16D6A0000A9D7 /* SystemConfiguration.framework in Frameworks */,
 				89EB399E1AB16ED800B1EB9D /* UIKit.framework in Frameworks */,
 				B3D2211017722AE800B7CB63 /* libLoopBack.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E4C9BC2B1AD6F9C800D70046 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E4C9BC361AD6F9C800D70046 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E4C9BC3A1AD6F9C800D70046 /* LoopBack.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -442,6 +529,8 @@
 				47C48BB41962123900995044 /* SLRemotingTests */,
 				B3D220FC17722AE800B7CB63 /* LoopBack */,
 				B3D2211117722AE800B7CB63 /* LoopBackTests */,
+				E4C9BC301AD6F9C800D70046 /* LoopBackOSX */,
+				E4C9BC3D1AD6F9C800D70046 /* LoopBackOSXTests */,
 				B3D220F917722AE800B7CB63 /* Frameworks */,
 				B3D220F817722AE800B7CB63 /* Products */,
 			);
@@ -453,6 +542,8 @@
 				B3D220F717722AE800B7CB63 /* libLoopBack.a */,
 				B3D2210817722AE800B7CB63 /* LoopBackTests.xctest */,
 				47D471B7196DF4A1002E2358 /* SLRemotingTests.xctest */,
+				E4C9BC2F1AD6F9C800D70046 /* LoopBack.framework */,
+				E4C9BC391AD6F9C800D70046 /* LoopBackOSXTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -532,6 +623,39 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		E4C9BC301AD6F9C800D70046 /* LoopBackOSX */ = {
+			isa = PBXGroup;
+			children = (
+				E4C9BC331AD6F9C800D70046 /* LoopBackOSX.h */,
+				E4C9BC311AD6F9C800D70046 /* Supporting Files */,
+			);
+			path = LoopBackOSX;
+			sourceTree = "<group>";
+		};
+		E4C9BC311AD6F9C800D70046 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				E4C9BC321AD6F9C800D70046 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		E4C9BC3D1AD6F9C800D70046 /* LoopBackOSXTests */ = {
+			isa = PBXGroup;
+			children = (
+				E4C9BC3E1AD6F9C800D70046 /* Supporting Files */,
+			);
+			path = LoopBackOSXTests;
+			sourceTree = "<group>";
+		};
+		E4C9BC3E1AD6F9C800D70046 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				E4C9BC3F1AD6F9C800D70046 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -567,6 +691,40 @@
 				47C48B951962120E00995044 /* SLAFHTTPClient.h in Headers */,
 				47C48BAE1962120E00995044 /* SLRemotingUtils.h in Headers */,
 				47C48BA01962120E00995044 /* SLAFPropertyListRequestOperation.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E4C9BC2C1AD6F9C800D70046 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E4C9BC671AD6FBE300D70046 /* SLRESTAdapter.h in Headers */,
+				E4C9BC691AD6FBEA00D70046 /* SLRESTContract.h in Headers */,
+				E4C9BC501AD6FB7100D70046 /* SLAFImageRequestOperation.h in Headers */,
+				E4C9BC751AD6FC2700D70046 /* LBUser.h in Headers */,
+				E4C9BC771AD6FC2D00D70046 /* LBAccessToken.h in Headers */,
+				E4C9BC6C1AD6FC0000D70046 /* LBInstallation.h in Headers */,
+				E4C9BC591AD6FBA200D70046 /* SLAFURLConnectionOperation.h in Headers */,
+				E4C9BC5B1AD6FBAA00D70046 /* SLAFXMLRequestOperation.h in Headers */,
+				E4C9BC731AD6FC2000D70046 /* LBRESTAdapter.h in Headers */,
+				E4C9BC5D1AD6FBB200D70046 /* UIImageView+SLAFNetworking.h in Headers */,
+				E4C9BC791AD6FC3400D70046 /* LBContainer.h in Headers */,
+				E4C9BC341AD6F9C800D70046 /* LoopBackOSX.h in Headers */,
+				E4C9BC701AD6FC1800D70046 /* LBModel.h in Headers */,
+				E4C9BC521AD6FB7F00D70046 /* SLAFJSONRequestOperation.h in Headers */,
+				E4C9BC7B1AD6FC6100D70046 /* LBFile.h in Headers */,
+				E4C9BC6F1AD6FC0F00D70046 /* LoopBack-Prefix.pch in Headers */,
+				E4C9BC641AD6FBD700D70046 /* SLRemoting.h in Headers */,
+				E4C9BC4C1AD6FB4800D70046 /* SLAFHTTPClient.h in Headers */,
+				E4C9BC541AD6FB8900D70046 /* SLAFNetworkActivityIndicatorManager.h in Headers */,
+				E4C9BC571AD6FB9A00D70046 /* SLAFPropertyListRequestOperation.h in Headers */,
+				E4C9BC611AD6FBC500D70046 /* SLObject.h in Headers */,
+				E4C9BC5F1AD6FBBE00D70046 /* SLAdapter.h in Headers */,
+				E4C9BC6E1AD6FC0800D70046 /* LoopBack.h in Headers */,
+				E4C9BC651AD6FBDB00D70046 /* SLRemotingUtils.h in Headers */,
+				E4C9BC631AD6FBD200D70046 /* SLRemoting-Prefix.pch in Headers */,
+				E4C9BC4E1AD6FB5300D70046 /* SLAFHTTPRequestOperation.h in Headers */,
+				E4C9BC561AD6FB9500D70046 /* SLAFNetworking.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -629,6 +787,42 @@
 			productReference = B3D2210817722AE800B7CB63 /* LoopBackTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		E4C9BC2E1AD6F9C800D70046 /* LoopBackOSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E4C9BC461AD6F9C800D70046 /* Build configuration list for PBXNativeTarget "LoopBackOSX" */;
+			buildPhases = (
+				E4C9BC2A1AD6F9C800D70046 /* Sources */,
+				E4C9BC2B1AD6F9C800D70046 /* Frameworks */,
+				E4C9BC2C1AD6F9C800D70046 /* Headers */,
+				E4C9BC2D1AD6F9C800D70046 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LoopBackOSX;
+			productName = LoopBackOSX;
+			productReference = E4C9BC2F1AD6F9C800D70046 /* LoopBack.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		E4C9BC381AD6F9C800D70046 /* LoopBackOSXTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E4C9BC471AD6F9C800D70046 /* Build configuration list for PBXNativeTarget "LoopBackOSXTests" */;
+			buildPhases = (
+				E4C9BC351AD6F9C800D70046 /* Sources */,
+				E4C9BC361AD6F9C800D70046 /* Frameworks */,
+				E4C9BC371AD6F9C800D70046 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E4C9BC3C1AD6F9C800D70046 /* PBXTargetDependency */,
+			);
+			name = LoopBackOSXTests;
+			productName = LoopBackOSXTests;
+			productReference = E4C9BC391AD6F9C800D70046 /* LoopBackOSXTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -637,6 +831,14 @@
 			attributes = {
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = StrongLoop;
+				TargetAttributes = {
+					E4C9BC2E1AD6F9C800D70046 = {
+						CreatedOnToolsVersion = 6.2;
+					};
+					E4C9BC381AD6F9C800D70046 = {
+						CreatedOnToolsVersion = 6.2;
+					};
+				};
 			};
 			buildConfigurationList = B3D220F217722AE800B7CB63 /* Build configuration list for PBXProject "LoopBack" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -655,6 +857,8 @@
 				B3DFA5B117970B1200F656D7 /* LoopBackFramework */,
 				B3F2EADD17AB214A00B52BBE /* LoopBackDocs */,
 				47D47190196DF4A1002E2358 /* SLRemotingTests */,
+				E4C9BC2E1AD6F9C800D70046 /* LoopBackOSX */,
+				E4C9BC381AD6F9C800D70046 /* LoopBackOSXTests */,
 			);
 		};
 /* End PBXProject section */
@@ -677,6 +881,20 @@
 				89D3DB0E1AB174F1005A1B90 /* InfoPlist.strings in Resources */,
 				B3D2211617722AE800B7CB63 /* InfoPlist.strings in Resources */,
 				47C48BD81962123900995044 /* SLRemotingTests-Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E4C9BC2D1AD6F9C800D70046 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E4C9BC371AD6F9C800D70046 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -815,6 +1033,52 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E4C9BC2A1AD6F9C800D70046 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E4C9BC4D1AD6FB4E00D70046 /* SLAFHTTPClient.m in Sources */,
+				E4C9BC5E1AD6FBB600D70046 /* UIImageView+SLAFNetworking.m in Sources */,
+				E4C9BC721AD6FC1E00D70046 /* LBModel.m in Sources */,
+				E4C9BC551AD6FB9200D70046 /* SLAFNetworkActivityIndicatorManager.m in Sources */,
+				E4C9BC621AD6FBCA00D70046 /* SLObject.m in Sources */,
+				E4C9BC6A1AD6FBEE00D70046 /* SLRESTContract.m in Sources */,
+				E45123371AE0422A00F0DB30 /* SLStreamParam.m in Sources */,
+				E4C9BC741AD6FC2400D70046 /* LBRESTAdapter.m in Sources */,
+				E4C9BC511AD6FB7800D70046 /* SLAFImageRequestOperation.m in Sources */,
+				E4C9BC7A1AD6FC5D00D70046 /* LBContainer.m in Sources */,
+				E4C9BC681AD6FBE700D70046 /* SLRESTAdapter.m in Sources */,
+				E4C9BC661AD6FBDF00D70046 /* SLRemotingUtils.m in Sources */,
+				E4C9BC601AD6FBC200D70046 /* SLAdapter.m in Sources */,
+				E4C9BC841AD7005E00D70046 /* LBInstallation.m in Sources */,
+				E4C9BC5A1AD6FBA700D70046 /* SLAFURLConnectionOperation.m in Sources */,
+				E4C9BC781AD6FC3100D70046 /* LBAccessToken.m in Sources */,
+				E4C9BC4F1AD6FB6E00D70046 /* SLAFHTTPRequestOperation.m in Sources */,
+				E4C9BC5C1AD6FBAE00D70046 /* SLAFXMLRequestOperation.m in Sources */,
+				E4C9BC581AD6FB9F00D70046 /* SLAFPropertyListRequestOperation.m in Sources */,
+				E4C9BC7C1AD6FC6800D70046 /* LBFile.m in Sources */,
+				E4C9BC761AD6FC2B00D70046 /* LBUser.m in Sources */,
+				E4C9BC531AD6FB8400D70046 /* SLAFJSONRequestOperation.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E4C9BC351AD6F9C800D70046 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E4C9BC811AD6FCAD00D70046 /* LBModelSubclassingTests.m in Sources */,
+				E4C9BC801AD6FCA800D70046 /* LBModelTests.m in Sources */,
+				E4C9BC4A1AD6FB3900D70046 /* SLRESTAdapterTests.m in Sources */,
+				E4C9BC7F1AD6FCA300D70046 /* LBFileTests.m in Sources */,
+				E4C9BC7D1AD6FC7000D70046 /* LBInstallationTests.m in Sources */,
+				E4C9BC7E1AD6FC9B00D70046 /* LBContainerTests.m in Sources */,
+				E4C9BC481AD6FAF400D70046 /* SLRESTAdapterNonRootTests.m in Sources */,
+				E4C9BC4B1AD6FB3D00D70046 /* SLRESTContractTests.m in Sources */,
+				E4C9BC491AD6FB3100D70046 /* SLRESTAdapterSSLTests.m in Sources */,
+				E4C9BC821AD6FCB300D70046 /* LBUserTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -832,6 +1096,11 @@
 			isa = PBXTargetDependency;
 			target = B3D220F617722AE800B7CB63 /* LoopBack */;
 			targetProxy = B3DFA5C317970B7400F656D7 /* PBXContainerItemProxy */;
+		};
+		E4C9BC3C1AD6F9C800D70046 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E4C9BC2E1AD6F9C800D70046 /* LoopBackOSX */;
+			targetProxy = E4C9BC3B1AD6F9C800D70046 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1065,6 +1334,146 @@
 			};
 			name = Release;
 		};
+		E4C9BC421AD6F9C800D70046 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = LoopBackOSX/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = LoopBack;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		E4C9BC431AD6F9C800D70046 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = LoopBackOSX/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = LoopBack;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		E4C9BC441AD6F9C800D70046 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = LoopBackOSXTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		E4C9BC451AD6F9C800D70046 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = LoopBackOSXTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1121,6 +1530,22 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		E4C9BC461AD6F9C800D70046 /* Build configuration list for PBXNativeTarget "LoopBackOSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E4C9BC421AD6F9C800D70046 /* Debug */,
+				E4C9BC431AD6F9C800D70046 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		E4C9BC471AD6F9C800D70046 /* Build configuration list for PBXNativeTarget "LoopBackOSXTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E4C9BC441AD6F9C800D70046 /* Debug */,
+				E4C9BC451AD6F9C800D70046 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/LoopBack.xcodeproj/project.pbxproj
+++ b/LoopBack.xcodeproj/project.pbxproj
@@ -96,7 +96,6 @@
 		47D4719C196DF4A1002E2358 /* LBModelSubclassingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2214117725A7F00B7CB63 /* LBModelSubclassingTests.m */; };
 		47D4719F196DF4A1002E2358 /* LBInstallationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4769FF08184D6F4F00E5152C /* LBInstallationTests.m */; };
 		47D471A0196DF4A1002E2358 /* LBFileTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A201A18A5856F006772C8 /* LBFileTests.m */; };
-		47D471A6196DF4A1002E2358 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2210917722AE800B7CB63 /* SenTestingKit.framework */; };
 		47D471A7196DF4A1002E2358 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220FA17722AE800B7CB63 /* Foundation.framework */; };
 		47D471A9196DF4A1002E2358 /* libLoopBack.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220F717722AE800B7CB63 /* libLoopBack.a */; };
 		47D471AF196DF4A1002E2358 /* SLRemotingTests-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BC41962123900995044 /* SLRemotingTests-Info.plist */; };
@@ -114,7 +113,6 @@
 		89EB399E1AB16ED800B1EB9D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2214317725DAB00B7CB63 /* UIKit.framework */; };
 		89EB399F1AB16ED900B1EB9D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2214317725DAB00B7CB63 /* UIKit.framework */; };
 		B3D220FB17722AE800B7CB63 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220FA17722AE800B7CB63 /* Foundation.framework */; };
-		B3D2210A17722AE800B7CB63 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2210917722AE800B7CB63 /* SenTestingKit.framework */; };
 		B3D2210D17722AE800B7CB63 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220FA17722AE800B7CB63 /* Foundation.framework */; };
 		B3D2211017722AE800B7CB63 /* libLoopBack.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220F717722AE800B7CB63 /* libLoopBack.a */; };
 		B3D2211617722AE800B7CB63 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = B3D2211417722AE800B7CB63 /* InfoPlist.strings */; };
@@ -224,7 +222,7 @@
 		47C48BC91962123900995044 /* SLRESTAdapterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLRESTAdapterTests.m; sourceTree = "<group>"; };
 		47C48BCA1962123900995044 /* SLRESTContractTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SLRESTContractTests.h; sourceTree = "<group>"; };
 		47C48BCB1962123900995044 /* SLRESTContractTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLRESTContractTests.m; sourceTree = "<group>"; };
-		47D471B7196DF4A1002E2358 /* LoopBackTests copy.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "LoopBackTests copy.octest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		47D471B7196DF4A1002E2358 /* SLRemotingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SLRemotingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		47F8E811185B7A4E0088BB73 /* LBPushNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LBPushNotification.h; sourceTree = "<group>"; };
 		47F8E812185B7A4E0088BB73 /* LBPushNotification.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBPushNotification.m; sourceTree = "<group>"; };
 		8973753C1AB2A60A00FB31A2 /* SLStreamParam.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SLStreamParam.h; sourceTree = "<group>"; };
@@ -239,8 +237,7 @@
 		B3D220FA17722AE800B7CB63 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		B3D220FE17722AE800B7CB63 /* LoopBack-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LoopBack-Prefix.pch"; sourceTree = "<group>"; };
 		B3D220FF17722AE800B7CB63 /* LoopBack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoopBack.h; sourceTree = "<group>"; };
-		B3D2210817722AE800B7CB63 /* LoopBackTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LoopBackTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
-		B3D2210917722AE800B7CB63 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
+		B3D2210817722AE800B7CB63 /* LoopBackTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LoopBackTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3D2211317722AE800B7CB63 /* LoopBackTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "LoopBackTests-Info.plist"; sourceTree = "<group>"; };
 		B3D2211517722AE800B7CB63 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B3D2212217722B1700B7CB63 /* LBModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LBModel.h; sourceTree = "<group>"; };
@@ -260,7 +257,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				47D471A6196DF4A1002E2358 /* SenTestingKit.framework in Frameworks */,
 				47D471A7196DF4A1002E2358 /* Foundation.framework in Frameworks */,
 				895B41811AB16D670000A9D7 /* MobileCoreServices.framework in Frameworks */,
 				895B41831AB16D6B0000A9D7 /* SystemConfiguration.framework in Frameworks */,
@@ -284,7 +280,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B3D2210A17722AE800B7CB63 /* SenTestingKit.framework in Frameworks */,
 				B3D2210D17722AE800B7CB63 /* Foundation.framework in Frameworks */,
 				895B41801AB16D660000A9D7 /* MobileCoreServices.framework in Frameworks */,
 				895B41821AB16D6A0000A9D7 /* SystemConfiguration.framework in Frameworks */,
@@ -456,8 +451,8 @@
 			isa = PBXGroup;
 			children = (
 				B3D220F717722AE800B7CB63 /* libLoopBack.a */,
-				B3D2210817722AE800B7CB63 /* LoopBackTests.octest */,
-				47D471B7196DF4A1002E2358 /* LoopBackTests copy.octest */,
+				B3D2210817722AE800B7CB63 /* LoopBackTests.xctest */,
+				47D471B7196DF4A1002E2358 /* SLRemotingTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -470,7 +465,6 @@
 				B3D2214317725DAB00B7CB63 /* UIKit.framework */,
 				0B278D50187B584F00FFC135 /* MobileCoreServices.framework */,
 				0B278D4A187B584A00FFC135 /* SystemConfiguration.framework */,
-				B3D2210917722AE800B7CB63 /* SenTestingKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -595,8 +589,8 @@
 			);
 			name = SLRemotingTests;
 			productName = LoopBackTests;
-			productReference = 47D471B7196DF4A1002E2358 /* LoopBackTests copy.octest */;
-			productType = "com.apple.product-type.bundle.ocunit-test";
+			productReference = 47D471B7196DF4A1002E2358 /* SLRemotingTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		B3D220F617722AE800B7CB63 /* LoopBack */ = {
 			isa = PBXNativeTarget;
@@ -632,8 +626,8 @@
 			);
 			name = LoopBackTests;
 			productName = LoopBackTests;
-			productReference = B3D2210817722AE800B7CB63 /* LoopBackTests.octest */;
-			productType = "com.apple.product-type.bundle.ocunit-test";
+			productReference = B3D2210817722AE800B7CB63 /* LoopBackTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -868,16 +862,17 @@
 					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
 					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
 					"\"$(SRCROOT)\"",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(inherited)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "LoopBack/LoopBack-Prefix.pch";
-				INFOPLIST_FILE = "LoopBackTests copy-Info.plist";
+				INFOPLIST_FILE = "LoopBackTests/LoopBackTests-Info.plist";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)\"",
 				);
-				PRODUCT_NAME = "LoopBackTests copy";
-				WRAPPER_EXTENSION = octest;
+				PRODUCT_NAME = SLRemotingTests;
 			};
 			name = Debug;
 		};
@@ -888,16 +883,17 @@
 					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
 					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
 					"\"$(SRCROOT)\"",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(inherited)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "LoopBack/LoopBack-Prefix.pch";
-				INFOPLIST_FILE = "LoopBackTests copy-Info.plist";
+				INFOPLIST_FILE = "LoopBackTests/LoopBackTests-Info.plist";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)\"",
 				);
-				PRODUCT_NAME = "LoopBackTests copy";
-				WRAPPER_EXTENSION = octest;
+				PRODUCT_NAME = SLRemotingTests;
 			};
 			name = Release;
 		};
@@ -1006,6 +1002,7 @@
 					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
 					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
 					"\"$(SRCROOT)\"",
+					"$(inherited)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "LoopBack/LoopBack-Prefix.pch";
@@ -1015,7 +1012,6 @@
 					"\"$(SRCROOT)\"",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Debug;
 		};
@@ -1026,6 +1022,7 @@
 					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
 					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
 					"\"$(SRCROOT)\"",
+					"$(inherited)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "LoopBack/LoopBack-Prefix.pch";
@@ -1035,7 +1032,6 @@
 					"\"$(SRCROOT)\"",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Release;
 		};

--- a/LoopBack.xcodeproj/xcshareddata/xcschemes/LoopBack.xcscheme
+++ b/LoopBack.xcodeproj/xcshareddata/xcschemes/LoopBack.xcscheme
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B3D2210717722AE800B7CB63"
-               BuildableName = "LoopBackTests.octest"
+               BuildableName = "LoopBackTests.xctest"
                BlueprintName = "LoopBackTests"
                ReferencedContainer = "container:LoopBack.xcodeproj">
             </BuildableReference>

--- a/LoopBack/LBInstallation.h
+++ b/LoopBack/LBInstallation.h
@@ -6,7 +6,7 @@
 #ifndef LoopBack_LBInstallation_h
 #define LoopBack_LBInstallation_h
 
-#import <LoopBack/LoopBack.h>
+#import "LoopBack.h"
 
 @class LBInstallation;
 @class LBInstallationRepository;

--- a/LoopBack/LBModel.h
+++ b/LoopBack/LBModel.h
@@ -5,7 +5,7 @@
  * @copyright (c) 2013 StrongLoop. All rights reserved.
  */
 
-#import <LoopBack/SLRemoting.h>
+#import "SLRemoting.h"
 
 /**
  * A local representative of a single model instance on the server. The data is

--- a/LoopBack/LBRESTAdapter.h
+++ b/LoopBack/LBRESTAdapter.h
@@ -5,7 +5,7 @@
  * @copyright (c) 2013 StrongLoop. All rights reserved.
  */
 
-#import <LoopBack/SLRemoting.h>
+#import "SLRemoting.h"
 
 #import "LBModel.h"
 

--- a/LoopBack/LoopBack.h
+++ b/LoopBack/LoopBack.h
@@ -8,7 +8,9 @@
 #import "LBModel.h"
 #import "LBRESTAdapter.h"
 #import "LBInstallation.h"
+#if !defined(TARGET_OS_MAC)
 #import "LBPushNotification.h"
+#endif
 #import "LBUser.h"
 #import "LBFile.h"
 #import "LBContainer.h"

--- a/LoopBackOSX/Info.plist
+++ b/LoopBackOSX/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.strongloop.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2015 StrongLoop. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/LoopBackOSX/LoopBackOSX.h
+++ b/LoopBackOSX/LoopBackOSX.h
@@ -1,0 +1,24 @@
+//
+//  LoopBackOSX.h
+//  LoopBackOSX
+//
+//  Created by Sylvain Ageneau on 4/9/15.
+//  Copyright (c) 2015 StrongLoop. All rights reserved.
+//
+
+#import "LBModel.h"
+#import "LBRESTAdapter.h"
+#import "LBInstallation.h"
+#import "LBUser.h"
+#import "LBFile.h"
+#import "LBContainer.h"
+
+//! Project version number for LoopBackOSX.
+FOUNDATION_EXPORT double LoopBackOSXVersionNumber;
+
+//! Project version string for LoopBackOSX.
+FOUNDATION_EXPORT const unsigned char LoopBackOSXVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <LoopBackOSX/PublicHeader.h>
+
+

--- a/LoopBackOSXTests/Info.plist
+++ b/LoopBackOSXTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.strongloop.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/LoopBackTests/LBContainerTests.h
+++ b/LoopBackTests/LBContainerTests.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2014 StrongLoop. All rights reserved.
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface LBContainerTests : SenTestCase
+@interface LBContainerTests : XCTestCase
 
 @end

--- a/LoopBackTests/LBContainerTests.m
+++ b/LoopBackTests/LBContainerTests.m
@@ -23,7 +23,7 @@
  * Create the default test suite to control the order of test methods
  */
 + (id)defaultTestSuite {
-    SenTestSuite *suite = [SenTestSuite testSuiteWithName:@"TestSuite for LBContainer."];
+    XCTestSuite *suite = [XCTestSuite testSuiteWithName:@"TestSuite for LBContainer."];
     [suite addTest:[self testCaseWithSelector:@selector(testGetAll)]];
     [suite addTest:[self testCaseWithSelector:@selector(testGetByName)]];
     [suite addTest:[self testCaseWithSelector:@selector(testCreate)]];
@@ -46,11 +46,11 @@
 - (void)testGetAll {
     ASYNC_TEST_START
     [self.repository getAllContainersWithSuccess:^(NSArray *containers) {
-        STAssertNotNil(containers, @"No containers returned.");
-        STAssertTrue(containers.count >= 2, [NSString stringWithFormat:@"Invalid # of containers returned: %lu", (unsigned long)containers.count]);
-        STAssertTrue([[containers[0] class] isSubclassOfClass:[LBContainer class]], @"Invalid class.");
-        STAssertEqualObjects(containers[0][@"name"], @"container1", @"Invalid name");
-        STAssertEqualObjects(containers[1][@"name"], @"container2", @"Invalid name");
+        XCTAssertNotNil(containers, @"No containers returned.");
+        XCTAssertTrue(containers.count >= 2, @"Invalid # of containers returned: %lu", (unsigned long)containers.count);
+        XCTAssertTrue([[containers[0] class] isSubclassOfClass:[LBContainer class]], @"Invalid class.");
+        XCTAssertEqualObjects(containers[0][@"name"], @"container1", @"Invalid name");
+        XCTAssertEqualObjects(containers[1][@"name"], @"container2", @"Invalid name");
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -59,8 +59,8 @@
 - (void)testGetByName {
     ASYNC_TEST_START
     [self.repository getContainerWithName:@"container1" success:^(LBContainer *container) {
-        STAssertNotNil(container, @"Container not found.");
-        STAssertEqualObjects(container.name, @"container1", @"Invalid name");
+        XCTAssertNotNil(container, @"Container not found.");
+        XCTAssertEqualObjects(container.name, @"container1", @"Invalid name");
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -78,7 +78,7 @@
 - (void)testRemove {
     ASYNC_TEST_START
     [self.repository getContainerWithName:@"containerTest" success:^(LBContainer *container) {
-        STAssertNotNil(container, @"Container not found.");
+        XCTAssertNotNil(container, @"Container not found.");
         [container deleteWithSuccess:^(void) {
             ASYNC_TEST_SIGNAL
         }failure:ASYNC_TEST_FAILURE_BLOCK];

--- a/LoopBackTests/LBFileTests.h
+++ b/LoopBackTests/LBFileTests.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2014 StrongLoop. All rights reserved.
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface LBFileTests : SenTestCase
+@interface LBFileTests : XCTestCase
 
 @end

--- a/LoopBackTests/LBFileTests.m
+++ b/LoopBackTests/LBFileTests.m
@@ -23,7 +23,7 @@
  * Create the default test suite to control the order of test methods
  */
 + (id)defaultTestSuite {
-    SenTestSuite *suite = [SenTestSuite testSuiteWithName:@"TestSuite for LBFile."];
+    XCTestSuite *suite = [XCTestSuite testSuiteWithName:@"TestSuite for LBFile."];
     [suite addTest:[self testCaseWithSelector:@selector(testGetByName)]];
     [suite addTest:[self testCaseWithSelector:@selector(testUpload)]];
     [suite addTest:[self testCaseWithSelector:@selector(testDownload)]];
@@ -46,8 +46,8 @@
     NSString *tmpDir = NSTemporaryDirectory();
     ASYNC_TEST_START
     [self.repository getFileWithName:@"f1.txt" localPath:tmpDir container:@"container1" success:^(LBFile *file) {
-        STAssertNotNil(file, @"File not found.");
-        STAssertEqualObjects(file.name, @"f1.txt", @"Invalid name");
+        XCTAssertNotNil(file, @"File not found.");
+        XCTAssertEqualObjects(file.name, @"f1.txt", @"Invalid name");
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -88,14 +88,14 @@
     
     ASYNC_TEST_START
     [self.repository getFileWithName:@"uploadTest.txt" localPath:tmpDir container:@"container1" success:^(LBFile *file) {
-        STAssertNotNil(file, @"File not found.");
-        STAssertEqualObjects(file.name, @"uploadTest.txt", @"Invalid name");
+        XCTAssertNotNil(file, @"File not found.");
+        XCTAssertEqualObjects(file.name, @"uploadTest.txt", @"Invalid name");
         [file downloadWithSuccess:^(void) {
-            STAssertTrue([fileManager fileExistsAtPath:fullPath], @"File missing.");
+            XCTAssertTrue([fileManager fileExistsAtPath:fullPath], @"File missing.");
             NSString *fileContents = [NSString stringWithContentsOfFile:fullPath
                                                                encoding:NSUTF8StringEncoding
                                                                   error:nil];
-            STAssertEqualObjects(fileContents, @"Upload test", @"File corrupted");
+            XCTAssertEqualObjects(fileContents, @"Upload test", @"File corrupted");
             ASYNC_TEST_SIGNAL
         } failure:ASYNC_TEST_FAILURE_BLOCK];
     } failure:ASYNC_TEST_FAILURE_BLOCK];

--- a/LoopBackTests/LBInstallationTests.h
+++ b/LoopBackTests/LBInstallationTests.h
@@ -1,5 +1,5 @@
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface LBInstallationTests : SenTestCase
+@interface LBInstallationTests : XCTestCase
 
 @end

--- a/LoopBackTests/LBInstallationTests.m
+++ b/LoopBackTests/LBInstallationTests.m
@@ -29,7 +29,7 @@ static id lastId = nil;
  * Create the default test suite to control the order of test methods
  */
 + (id)defaultTestSuite {
-    SenTestSuite *suite = [SenTestSuite testSuiteWithName:@"TestSuite for LBInstallation."];
+    XCTestSuite *suite = [XCTestSuite testSuiteWithName:@"TestSuite for LBInstallation."];
     [suite addTest:[self testCaseWithSelector:@selector(testSingletonRepository)]];
     [suite addTest:[self testCaseWithSelector:@selector(testRegister)]];
     [suite addTest:[self testCaseWithSelector:@selector(testFind)]];
@@ -61,7 +61,7 @@ static id lastId = nil;
 - (void)testSingletonRepository {
     LBInstallationRepository* r1 = [LBInstallationRepository repository];
     LBInstallationRepository* r2 = [LBInstallationRepository repository];
-    STAssertEquals(r1, r2, @"LBInstallationRepository.repository is a singleton");
+    XCTAssertEqual(r1, r2, @"LBInstallationRepository.repository is a singleton");
 }
 
 - (void)testRegister {
@@ -78,7 +78,7 @@ static id lastId = nil;
                                       success:^(LBInstallation *model) {
                                           // NSLog(@"Completed with: %@", model._id);
                                           lastId = model._id;
-                                          STAssertNotNil(model._id, @"Invalid id");
+                                          XCTAssertNotNil(model._id, @"Invalid id");
                                           ASYNC_TEST_SIGNAL
                                       }
                                       failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -90,8 +90,8 @@ static id lastId = nil;
     ASYNC_TEST_START
     [self.repository findById:lastId
                       success:^(LBModel *model) {
-                          STAssertNotNil(model, @"No model found with ID 1");
-                          STAssertTrue([[model class] isSubclassOfClass:[LBInstallation class]], @"Invalid class.");
+                          XCTAssertNotNil(model, @"No model found with ID 1");
+                          XCTAssertTrue([[model class] isSubclassOfClass:[LBInstallation class]], @"Invalid class.");
                           ASYNC_TEST_SIGNAL
                       } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -100,8 +100,8 @@ static id lastId = nil;
 - (void)testAll {
     ASYNC_TEST_START
     [self.repository allWithSuccess:^(NSArray *models) {
-        STAssertNotNil(models, @"No models returned.");
-        STAssertTrue([models count] >= 1, [NSString stringWithFormat:@"Invalid # of models returned: %lu", (unsigned long)[models count]]);
+        XCTAssertNotNil(models, @"No models returned.");
+        XCTAssertTrue([models count] >= 1, @"Invalid # of models returned: %lu", (unsigned long)[models count]);
         // STAssertTrue([[models[0] class] isSubclassOfClass:[LBInstallation class]], @"Invalid class.");
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -125,9 +125,9 @@ static id lastId = nil;
                                           // [rfeng] We have to do NSString comparision
                                           id id1 = model._id;
                                           id id2 = lastId;
-                                          STAssertTrue([id1 isEqualToValue:id2], @"The ids should be the same");
+                                          XCTAssertTrue([id1 isEqualToValue:id2], @"The ids should be the same");
                                           lastId = model._id;
-                                          STAssertNotNil(model._id, @"Invalid id");
+                                          XCTAssertNotNil(model._id, @"Invalid id");
                                           ASYNC_TEST_SIGNAL
                                       }
                                       failure:ASYNC_TEST_FAILURE_BLOCK];

--- a/LoopBackTests/LBModelSubclassingTests.h
+++ b/LoopBackTests/LBModelSubclassingTests.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2013 StrongLoop. All rights reserved.
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface LBModelSubclassingTests : SenTestCase
+@interface LBModelSubclassingTests : XCTestCase
 
 @end

--- a/LoopBackTests/LBModelSubclassingTests.m
+++ b/LoopBackTests/LBModelSubclassingTests.m
@@ -49,7 +49,7 @@ static NSNumber *lastId;
  * Create the default test suite to control the order of test methods
  */
 + (id)defaultTestSuite {
-    SenTestSuite *suite = [SenTestSuite testSuiteWithName:@"TestSuite for LBModel subclasses."];
+    XCTestSuite *suite = [XCTestSuite testSuiteWithName:@"TestSuite for LBModel subclasses."];
     [suite addTest:[self testCaseWithSelector:@selector(testCreate)]];
     [suite addTest:[self testCaseWithSelector:@selector(testFind)]];
     [suite addTest:[self testCaseWithSelector:@selector(testAll)]];
@@ -72,14 +72,14 @@ static NSNumber *lastId;
 - (void)testCreate {
     Widget *model = (Widget*)[self.repository modelWithDictionary:@{ @"name": @"Foobar", @"bars": @1 }];
 
-    STAssertEqualObjects(model.name, @"Foobar", @"Invalid name.");
-    STAssertEqualObjects(model.bars, @1, @"Invalid bars.");
-    STAssertNil(model._id, nil, @"Invalid id");
+    XCTAssertEqualObjects(model.name, @"Foobar", @"Invalid name.");
+    XCTAssertEqualObjects(model.bars, @1, @"Invalid bars.");
+    XCTAssertNil(model._id, @"Invalid id");
 
     ASYNC_TEST_START
     [model saveWithSuccess:^{
         lastId = model._id;
-        STAssertNotNil(model._id, @"Invalid id");
+        XCTAssertNotNil(model._id, @"Invalid id");
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -89,10 +89,10 @@ static NSNumber *lastId;
     ASYNC_TEST_START
     [self.repository findById:@2
                        success:^(LBModel *model) {
-                           STAssertNotNil(model, @"No model found with ID 2");
-                           STAssertTrue([[model class] isSubclassOfClass:[Widget class]], @"Invalid class.");
-                           STAssertEqualObjects(((Widget *)model).name, @"Bar", @"Invalid name");
-                           STAssertEqualObjects(((Widget *)model).bars, @1, @"Invalid bars");
+                           XCTAssertNotNil(model, @"No model found with ID 2");
+                           XCTAssertTrue([[model class] isSubclassOfClass:[Widget class]], @"Invalid class.");
+                           XCTAssertEqualObjects(((Widget *)model).name, @"Bar", @"Invalid name");
+                           XCTAssertEqualObjects(((Widget *)model).bars, @1, @"Invalid bars");
                            ASYNC_TEST_SIGNAL
                        } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -101,13 +101,13 @@ static NSNumber *lastId;
 - (void)testAll {
     ASYNC_TEST_START
     [self.repository allWithSuccess:^(NSArray *models) {
-        STAssertNotNil(models, @"No models returned.");
-        STAssertTrue([models count] >= 2, [NSString stringWithFormat:@"Invalid # of models returned: %lu", (unsigned long)[models count]]);
-        STAssertTrue([[models[0] class] isSubclassOfClass:[Widget class]], @"Invalid class.");
-        STAssertEqualObjects(((Widget *)models[0]).name, @"Foo", @"Invalid name.");
-        STAssertEqualObjects(((Widget *)models[0]).bars, @0, @"Invalid bars");
-        STAssertEqualObjects(((Widget *)models[1]).name, @"Bar", @"Invalid name");
-        STAssertEqualObjects(((Widget *)models[1]).bars, @1, @"Invalid bars");
+        XCTAssertNotNil(models, @"No models returned.");
+        XCTAssertTrue([models count] >= 2, @"Invalid # of models returned: %lu", (unsigned long)[models count]);
+        XCTAssertTrue([[models[0] class] isSubclassOfClass:[Widget class]], @"Invalid class.");
+        XCTAssertEqualObjects(((Widget *)models[0]).name, @"Foo", @"Invalid name.");
+        XCTAssertEqualObjects(((Widget *)models[0]).bars, @0, @"Invalid bars");
+        XCTAssertEqualObjects(((Widget *)models[1]).name, @"Bar", @"Invalid name");
+        XCTAssertEqualObjects(((Widget *)models[1]).bars, @1, @"Invalid bars");
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -116,16 +116,15 @@ static NSNumber *lastId;
 - (void)testUpdate {
     ASYNC_TEST_START
     LBModelFindSuccessBlock verify = ^(LBModel *model) {
-        STAssertNotNil(model, @"No model found with ID 2");
-        STAssertTrue([[model class] isSubclassOfClass:[Widget class]], @"Invalid class.");
-        STAssertEqualObjects(((Widget *)model).name, @"Barfoo", @"Invalid name");
-        STAssertEqualObjects(((Widget *)model).bars, @1, @"Invalid bars");
+        XCTAssertNotNil(model, @"No model found with ID 2");
+        XCTAssertTrue([[model class] isSubclassOfClass:[Widget class]], @"Invalid class.");
+        XCTAssertEqualObjects(((Widget *)model).name, @"Barfoo", @"Invalid name");
+        XCTAssertEqualObjects(((Widget *)model).bars, @1, @"Invalid bars");
 
         ((Widget *)model).name = @"Bar";
         [model saveWithSuccess:^{
             ASYNC_TEST_SIGNAL
         } failure:ASYNC_TEST_FAILURE_BLOCK];
-        ASYNC_TEST_SIGNAL
     };
 
     LBModelSaveSuccessBlock findAgain = ^() {
@@ -133,7 +132,7 @@ static NSNumber *lastId;
     };
 
     LBModelFindSuccessBlock update = ^(LBModel *model) {
-        STAssertNotNil(model, @"No model found with ID 2");
+        XCTAssertNotNil(model, @"No model found with ID 2");
         ((Widget *)model).name = @"Barfoo";
         [model saveWithSuccess:findAgain failure:ASYNC_TEST_FAILURE_BLOCK];
     };

--- a/LoopBackTests/LBModelTests.h
+++ b/LoopBackTests/LBModelTests.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2013 StrongLoop. All rights reserved.
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface LBModelTests : SenTestCase
+@interface LBModelTests : XCTestCase
 
 @end

--- a/LoopBackTests/LBModelTests.m
+++ b/LoopBackTests/LBModelTests.m
@@ -25,7 +25,7 @@ static NSNumber *lastId;
  * Create the default test suite to control the order of test methods
  */
 + (id)defaultTestSuite {
-    SenTestSuite *suite = [SenTestSuite testSuiteWithName:@"TestSuite for LBModel."];
+    XCTestSuite *suite = [XCTestSuite testSuiteWithName:@"TestSuite for LBModel."];
     [suite addTest:[self testCaseWithSelector:@selector(testCreate)]];
     [suite addTest:[self testCaseWithSelector:@selector(testFind)]];
     [suite addTest:[self testCaseWithSelector:@selector(testAll)]];
@@ -49,15 +49,15 @@ static NSNumber *lastId;
 - (void)testCreate {
     LBModel __block *model = [self.repository modelWithDictionary:@{ @"name": @"Foobar", @"bars": @1 }];
 
-    STAssertEqualObjects(@"Foobar", model[@"name"], @"Invalid name.");
-    STAssertEqualObjects(@1, model[@"bars"], @"Invalid bars.");
-    STAssertNil(model._id, @"Invalid id");
+    XCTAssertEqualObjects(@"Foobar", model[@"name"], @"Invalid name.");
+    XCTAssertEqualObjects(@1, model[@"bars"], @"Invalid bars.");
+    XCTAssertNil(model._id, @"Invalid id");
 
     ASYNC_TEST_START
     [model saveWithSuccess:^{
         NSLog(@"Completed with: %@", model._id);
         lastId = model._id;
-        STAssertNotNil(model._id, @"Invalid id");
+        XCTAssertNotNil(model._id, @"Invalid id");
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -67,10 +67,10 @@ static NSNumber *lastId;
     ASYNC_TEST_START
     [self.repository findById:@2
                        success:^(LBModel *model) {
-                           STAssertNotNil(model, @"No model found with ID 2");
-                           STAssertTrue([[model class] isSubclassOfClass:[LBModel class]], @"Invalid class.");
-                           STAssertEqualObjects(model[@"name"], @"Bar", @"Invalid name");
-                           STAssertEqualObjects(model[@"bars"], @1, @"Invalid bars");
+                           XCTAssertNotNil(model, @"No model found with ID 2");
+                           XCTAssertTrue([[model class] isSubclassOfClass:[LBModel class]], @"Invalid class.");
+                           XCTAssertEqualObjects(model[@"name"], @"Bar", @"Invalid name");
+                           XCTAssertEqualObjects(model[@"bars"], @1, @"Invalid bars");
                            ASYNC_TEST_SIGNAL
                        } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -79,13 +79,13 @@ static NSNumber *lastId;
 - (void)testAll {
     ASYNC_TEST_START
     [self.repository allWithSuccess:^(NSArray *models) {
-        STAssertNotNil(models, @"No models returned.");
-        STAssertTrue([models count] >= 2, [NSString stringWithFormat:@"Invalid # of models returned: %lu", (unsigned long)[models count]]);
-        STAssertTrue([[models[0] class] isSubclassOfClass:[LBModel class]], @"Invalid class.");
-        STAssertEqualObjects(models[0][@"name"], @"Foo", @"Invalid name");
-        STAssertEqualObjects(models[0][@"bars"], @0, @"Invalid bars");
-        STAssertEqualObjects(models[1][@"name"], @"Bar", @"Invalid name");
-        STAssertEqualObjects(models[1][@"bars"], @1, @"Invalid bars");
+        XCTAssertNotNil(models, @"No models returned.");
+        XCTAssertTrue([models count] >= 2, @"Invalid # of models returned: %lu", (unsigned long)[models count]);
+        XCTAssertTrue([[models[0] class] isSubclassOfClass:[LBModel class]], @"Invalid class.");
+        XCTAssertEqualObjects(models[0][@"name"], @"Foo", @"Invalid name");
+        XCTAssertEqualObjects(models[0][@"bars"], @0, @"Invalid bars");
+        XCTAssertEqualObjects(models[1][@"name"], @"Bar", @"Invalid name");
+        XCTAssertEqualObjects(models[1][@"bars"], @1, @"Invalid bars");
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -94,9 +94,9 @@ static NSNumber *lastId;
 - (void)testUpdate {
     ASYNC_TEST_START
     LBModelFindSuccessBlock verify = ^(LBModel *model) {
-        STAssertNotNil(model, @"No model found with ID 2");
-        STAssertEqualObjects(model[@"name"], @"Barfoo", @"Invalid name");
-        STAssertEqualObjects(model[@"bars"], @1, @"Invalid bars");
+        XCTAssertNotNil(model, @"No model found with ID 2");
+        XCTAssertEqualObjects(model[@"name"], @"Barfoo", @"Invalid name");
+        XCTAssertEqualObjects(model[@"bars"], @1, @"Invalid bars");
 
         model[@"name"] = @"Bar";
         [model saveWithSuccess:^{
@@ -109,7 +109,7 @@ static NSNumber *lastId;
     };
 
     LBModelFindSuccessBlock update = ^(LBModel *model) {
-        STAssertNotNil(model, @"No model found with ID 2");
+        XCTAssertNotNil(model, @"No model found with ID 2");
         model[@"name"] = @"Barfoo";
         [model saveWithSuccess:findAgain failure:ASYNC_TEST_FAILURE_BLOCK];
     };

--- a/LoopBackTests/LBRESTAdapterTests.m
+++ b/LoopBackTests/LBRESTAdapterTests.m
@@ -5,13 +5,13 @@
 //  Copyright (c) 2015 StrongLoop. All rights reserved.
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import "LBRESTAdapter.h"
 
 static NSString * const SERVER_URL = @"http://localhost:3001";
 
-@interface LBRESTAdapterTests : SenTestCase
+@interface LBRESTAdapterTests : XCTestCase
 
 @property (nonatomic, strong) LBRESTAdapter *adapter;
 
@@ -32,12 +32,12 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
     self.adapter.accessToken = @"an-access-token";
 
     LBRESTAdapter *anotherAdapter = [LBRESTAdapter adapterWithURL:[NSURL URLWithString:SERVER_URL]];
-    STAssertEqualObjects(anotherAdapter.accessToken, @"an-access-token", @"Invalid access token");
+    XCTAssertEqualObjects(anotherAdapter.accessToken, @"an-access-token", @"Invalid access token");
 
     self.adapter.accessToken = @"a-different-access-token";
 
     LBRESTAdapter *yetAnotherAdapter = [LBRESTAdapter adapterWithURL:[NSURL URLWithString:SERVER_URL]];
-    STAssertEqualObjects(yetAnotherAdapter.accessToken, @"a-different-access-token", @"Invalid access token");
+    XCTAssertEqualObjects(yetAnotherAdapter.accessToken, @"a-different-access-token", @"Invalid access token");
 
     self.adapter.accessToken = nil;
 }

--- a/LoopBackTests/LBUserTests.h
+++ b/LoopBackTests/LBUserTests.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2014 StrongLoop. All rights reserved.
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface LBUserTests : SenTestCase
+@interface LBUserTests : XCTestCase
 
 @end

--- a/LoopBackTests/LBUserTests.m
+++ b/LoopBackTests/LBUserTests.m
@@ -61,7 +61,7 @@ typedef void (^GivenCustomerSuccessBlock)(Customer *customer);
  * Create the default test suite to control the order of test methods
  */
 + (id)defaultTestSuite {
-    SenTestSuite *suite = [SenTestSuite testSuiteWithName:@"TestSuite for LBContainer."];
+    XCTestSuite *suite = [XCTestSuite testSuiteWithName:@"TestSuite for LBContainer."];
     [suite addTest:[self testCaseWithSelector:@selector(testCreateSaveRemove)]];
     [suite addTest:[self testCaseWithSelector:@selector(testLoginLogout)]];
     [suite addTest:[self testCaseWithSelector:@selector(testSetsCurrentUserIdOnLogin)]];
@@ -97,10 +97,10 @@ typedef void (^GivenCustomerSuccessBlock)(Customer *customer);
 
     Customer __block *customer = (Customer*)[self.repository createUserWithEmail:userEmail
                                                                         password:USER_PASSWORD];
-    STAssertNil(customer._id, @"User id should be nil before save");
+    XCTAssertNil(customer._id, @"User id should be nil before save");
 
     [customer saveWithSuccess:^{
-        STAssertNotNil(customer._id, @"User id should not be nil after save");
+        XCTAssertNotNil(customer._id, @"User id should not be nil after save");
 
         [self.repository userByLoginWithEmail:userEmail password:USER_PASSWORD success:^(LBUser *user) {
             [user destroyWithSuccess:^(void) {
@@ -115,9 +115,9 @@ typedef void (^GivenCustomerSuccessBlock)(Customer *customer);
     ASYNC_TEST_START
     [self givenCustomerWithSuccess:^(Customer *customer) {
         [self.repository userByLoginWithEmail:customer.email password:USER_PASSWORD success:^(LBUser *user) {
-            STAssertNotNil(user, @"User should not be nil");
-            STAssertNotNil(user._id, @"User id should not be nil");
-            STAssertEqualObjects(user.email, customer.email, @"Invalid email");
+            XCTAssertNotNil(user, @"User should not be nil");
+            XCTAssertNotNil(user._id, @"User id should not be nil");
+            XCTAssertEqualObjects(user.email, customer.email, @"Invalid email");
 
             [self.repository logoutWithSuccess:^(void) {
                 ASYNC_TEST_SIGNAL
@@ -130,7 +130,7 @@ typedef void (^GivenCustomerSuccessBlock)(Customer *customer);
 - (void)testSetsCurrentUserIdOnLogin {
     ASYNC_TEST_START
     [self givenLoggedInCustomerWithSuccess:^(Customer *customer) {
-        STAssertEqualObjects(customer._id, self.repository.currentUserId, @"Invalid current user ID");
+        XCTAssertEqualObjects(customer._id, self.repository.currentUserId, @"Invalid current user ID");
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -140,7 +140,7 @@ typedef void (^GivenCustomerSuccessBlock)(Customer *customer);
     ASYNC_TEST_START
     [self givenLoggedInCustomerWithSuccess:^(Customer *customer) {
         CustomerRepository *anotherRepo = (CustomerRepository*)[self.adapter repositoryWithClass:[CustomerRepository class]];
-        STAssertEqualObjects(customer._id, anotherRepo.currentUserId, @"Invalid current user ID");
+        XCTAssertEqualObjects(customer._id, anotherRepo.currentUserId, @"Invalid current user ID");
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -149,9 +149,9 @@ typedef void (^GivenCustomerSuccessBlock)(Customer *customer);
 - (void)testClearsCurrentUserIdOnLogout {
     ASYNC_TEST_START
     [self givenLoggedInCustomerWithSuccess:^(Customer *customer) {
-        STAssertEqualObjects(customer._id, self.repository.currentUserId, @"Invalid current user ID");
+        XCTAssertEqualObjects(customer._id, self.repository.currentUserId, @"Invalid current user ID");
         [self.repository logoutWithSuccess:^(void) {
-            STAssertNil(self.repository.currentUserId, @"Invalid current user ID");
+            XCTAssertNil(self.repository.currentUserId, @"Invalid current user ID");
             // The following second try to logout should fail if the first logout succeeded
             [self.repository logoutWithSuccess:ASYNC_TEST_FAILURE_BLOCK
                                        failure:^(NSError *error) {
@@ -164,13 +164,13 @@ typedef void (^GivenCustomerSuccessBlock)(Customer *customer);
 
 - (void)testGetCachedCurrentUserReturnsNilInitially {
     LBUser *cached = self.repository.cachedCurrentUser;
-    STAssertNil(cached, @"Cached current user should be nil initially");
+    XCTAssertNil(cached, @"Cached current user should be nil initially");
 }
 
 - (void)testFindCurrentUserReturnsNilWhenNotLoggedIn {
     ASYNC_TEST_START
     [self.repository findCurrentUserWithSuccess:^(LBUser *current) {
-        STAssertNil(current, @"Current user should be nil when not logged in");
+        XCTAssertNil(current, @"Current user should be nil when not logged in");
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -180,8 +180,8 @@ typedef void (^GivenCustomerSuccessBlock)(Customer *customer);
     ASYNC_TEST_START
     [self givenLoggedInCustomerWithSuccess:^(Customer *customer) {
         [self.repository findCurrentUserWithSuccess:^(LBUser *current) {
-            STAssertEqualObjects(customer._id, current._id, @"Invalid current user");
-            STAssertEqualObjects(customer.email, current.email, @"Invalid current user");
+            XCTAssertEqualObjects(customer._id, current._id, @"Invalid current user");
+            XCTAssertEqualObjects(customer.email, current.email, @"Invalid current user");
             ASYNC_TEST_SIGNAL
         } failure:ASYNC_TEST_FAILURE_BLOCK];
     } failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -193,7 +193,7 @@ typedef void (^GivenCustomerSuccessBlock)(Customer *customer);
     [self givenLoggedInCustomerWithSuccess:^(Customer *customer) {
         [self.repository findCurrentUserWithSuccess:^(LBUser *current) {
             LBUser *cached = self.repository.cachedCurrentUser;
-            STAssertEqualObjects(current, cached, @"Invalid cached current user");
+            XCTAssertEqualObjects(current, cached, @"Invalid cached current user");
             ASYNC_TEST_SIGNAL
         } failure:ASYNC_TEST_FAILURE_BLOCK];
     } failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -204,7 +204,7 @@ typedef void (^GivenCustomerSuccessBlock)(Customer *customer);
     ASYNC_TEST_START
     [self givenLoggedInCustomerWithSuccess:^(Customer *customer) {
         LBUser *cached = self.repository.cachedCurrentUser;
-        STAssertEqualObjects(customer, cached, @"Invalid cached current user");
+        XCTAssertEqualObjects(customer, cached, @"Invalid cached current user");
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
@@ -215,7 +215,7 @@ typedef void (^GivenCustomerSuccessBlock)(Customer *customer);
     [self givenLoggedInCustomerWithSuccess:^(Customer *customer) {
         [self.repository logoutWithSuccess:^(void) {
             LBUser *cached = self.repository.cachedCurrentUser;
-            STAssertNil(cached, @"Cached current user should be nil after logout");
+            XCTAssertNil(cached, @"Cached current user should be nil after logout");
             ASYNC_TEST_SIGNAL
         } failure:ASYNC_TEST_FAILURE_BLOCK];
     } failure:ASYNC_TEST_FAILURE_BLOCK];

--- a/LoopBackTests/server/package.json
+++ b/LoopBackTests/server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "loopback": "^2.14.0",
-    "loopback-component-push": "^1.4.4",
+    "loopback-component-push": "^1.5.1",
     "loopback-component-storage": "^1.3.1",
     "morgan": "^1.5.2"
   }

--- a/SLAFNetworking/SLAFImageRequestOperation.m
+++ b/SLAFNetworking/SLAFImageRequestOperation.m
@@ -108,8 +108,8 @@ static dispatch_queue_t image_request_operation_processing_queue() {
 										 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSImage *image))success
 										 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
 {
-    AFImageRequestOperation *requestOperation = [(AFImageRequestOperation *)[self alloc] initWithRequest:urlRequest];
-    [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
+    SLAFImageRequestOperation *requestOperation = [(SLAFImageRequestOperation *)[self alloc] initWithRequest:urlRequest];
+    [requestOperation setCompletionBlockWithSuccess:^(SLAFHTTPRequestOperation *operation, id responseObject) {
         if (success) {
             NSImage *image = responseObject;
             if (imageProcessingBlock) {
@@ -124,7 +124,7 @@ static dispatch_queue_t image_request_operation_processing_queue() {
                 success(operation.request, operation.response, image);
             }
         }
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(SLAFHTTPRequestOperation *operation, NSError *error) {
         if (failure) {
             failure(operation.request, operation.response, error);
         }

--- a/SLAFNetworking/SLAFXMLRequestOperation.m
+++ b/SLAFNetworking/SLAFXMLRequestOperation.m
@@ -72,15 +72,15 @@ static dispatch_queue_t xml_request_operation_processing_queue() {
 											   success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSXMLDocument *document))success
 											   failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSXMLDocument *document))failure
 {
-    AFXMLRequestOperation *requestOperation = [[self alloc] initWithRequest:urlRequest];
-    [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, __unused id responseObject) {
+    SLAFXMLRequestOperation *requestOperation = [[self alloc] initWithRequest:urlRequest];
+    [requestOperation setCompletionBlockWithSuccess:^(SLAFHTTPRequestOperation *operation, __unused id responseObject) {
         if (success) {
-            NSXMLDocument *XMLDocument = [(AFXMLRequestOperation *)operation responseXMLDocument];
+            NSXMLDocument *XMLDocument = [(SLAFXMLRequestOperation *)operation responseXMLDocument];
             success(operation.request, operation.response, XMLDocument);
         }
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(SLAFHTTPRequestOperation *operation, NSError *error) {
         if (failure) {
-            NSXMLDocument *XMLDocument = [(AFXMLRequestOperation *)operation responseXMLDocument];
+            NSXMLDocument *XMLDocument = [(SLAFXMLRequestOperation *)operation responseXMLDocument];
             failure(operation.request, operation.response, error, XMLDocument);
         }
     }];

--- a/SLRemoting/SLRemotingUtils.h
+++ b/SLRemoting/SLRemotingUtils.h
@@ -10,27 +10,25 @@
 /**
  * Marks the start of an asynchronous unit test.
  */
-#define ASYNC_TEST_START dispatch_semaphore_t sen_semaphore = dispatch_semaphore_create(0);
+#define ASYNC_TEST_START XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithUTF8String:__FUNCTION__]];
 
 /**
  * Marks the end of an asynchronous unit test.
  */
-#define ASYNC_TEST_END \
-while (dispatch_semaphore_wait(sen_semaphore, DISPATCH_TIME_NOW)) \
-    [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:10]];
+#define ASYNC_TEST_END [self waitForExpectationsWithTimeout:10 handler:nil];
 
 /**
  * Signals the completion of an asynchronous unit test.
  */
-#define ASYNC_TEST_SIGNAL dispatch_semaphore_signal(sen_semaphore);
+#define ASYNC_TEST_SIGNAL [expectation fulfill];
 
 /**
  * Fails an asynchronous unit test, additionally signaling its completion.
  */
 #define ASYNC_TEST_FAILURE_BLOCK \
 ^(NSError *error) { \
-    STFail(error.description); \
-    ASYNC_TEST_SIGNAL \
+    XCTFail(@"Test failed: %@", error.description); \
+    [expectation fulfill]; \
 }
 
 /**

--- a/SLRemotingTests/SLRESTAdapterNonRootTests.h
+++ b/SLRemotingTests/SLRESTAdapterNonRootTests.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2013 StrongLoop. All rights reserved.
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface SLRESTAdapterNonRootTests : SenTestCase
+@interface SLRESTAdapterNonRootTests : XCTestCase
 
 @end

--- a/SLRemotingTests/SLRESTAdapterNonRootTests.m
+++ b/SLRemotingTests/SLRESTAdapterNonRootTests.m
@@ -34,8 +34,8 @@
     [adapter invokeStaticMethod:@"getMsg"
                      parameters:nil
                         success:^(id value) {
-                            STAssertNotNil(value, @"No value returned.");
-                            STAssertTrue([@"Hello" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                            XCTAssertNotNil(value, @"No value returned.");
+                            XCTAssertTrue([@"Hello" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                             ASYNC_TEST_SIGNAL
                         }
                         failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -49,8 +49,8 @@
     [adapter invokeStaticMethod:@"convertMsg"
                      parameters:@{ @"str": @"somevalue" }
                         success:^(id value) {
-                            STAssertNotNil(value, @"No value returned.");
-                            STAssertTrue([@"CONVERTED: SOMEVALUE" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                            XCTAssertNotNil(value, @"No value returned.");
+                            XCTAssertTrue([@"CONVERTED: SOMEVALUE" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                             ASYNC_TEST_SIGNAL
                         }
                         failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -64,8 +64,8 @@
     [adapter invokeStaticMethod:@"getMsg"
                      parameters:nil
                         success:^(id value) {
-                            STAssertNotNil(value, @"No value returned.");
-                            STAssertTrue([@"Hello" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                            XCTAssertNotNil(value, @"No value returned.");
+                            XCTAssertTrue([@"Hello" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                             ASYNC_TEST_SIGNAL
                         }
                         failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -79,8 +79,8 @@
     [adapter invokeStaticMethod:@"convertMsg"
                      parameters:@{ @"str": @"somevalue" }
                         success:^(id value) {
-                            STAssertNotNil(value, @"No value returned.");
-                            STAssertTrue([@"CONVERTED: SOMEVALUE" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                            XCTAssertNotNil(value, @"No value returned.");
+                            XCTAssertTrue([@"CONVERTED: SOMEVALUE" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                             ASYNC_TEST_SIGNAL
                         }
                         failure:ASYNC_TEST_FAILURE_BLOCK];

--- a/SLRemotingTests/SLRESTAdapterSSLTests.m
+++ b/SLRemotingTests/SLRESTAdapterSSLTests.m
@@ -37,8 +37,8 @@
     [adapter invokeStaticMethod:@"simple.getSecret"
                      parameters:nil
                         success:^(id value) {
-                            STAssertNotNil(value, @"No value returned.");
-                            STAssertTrue([@"shhh!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                            XCTAssertNotNil(value, @"No value returned.");
+                            XCTAssertTrue([@"shhh!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                             ASYNC_TEST_SIGNAL
                         }
                         failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -50,8 +50,8 @@
     [adapter invokeStaticMethod:@"simple.transform"
                      parameters:@{ @"str": @"somevalue" }
                         success:^(id value) {
-                            STAssertNotNil(value, @"No value returned.");
-                            STAssertTrue([@"transformed: somevalue" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                            XCTAssertNotNil(value, @"No value returned.");
+                            XCTAssertTrue([@"transformed: somevalue" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                             ASYNC_TEST_SIGNAL
                         }
                         failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -64,8 +64,8 @@
             constructorParameters:@{ @"name": @"somename" }
                        parameters:nil
                           success:^(id value) {
-                              STAssertNotNil(value, @"No value returned.");
-                              STAssertTrue([@"somename" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                              XCTAssertNotNil(value, @"No value returned.");
+                              XCTAssertTrue([@"somename" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                               ASYNC_TEST_SIGNAL
                           }
                           failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -78,8 +78,8 @@
             constructorParameters:@{ @"name": @"somename" }
                        parameters:@{ @"other": @"othername" }
                           success:^(id value) {
-                              STAssertNotNil(value, @"No value returned.");
-                              STAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                              XCTAssertNotNil(value, @"No value returned.");
+                              XCTAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                               ASYNC_TEST_SIGNAL
                           }
                           failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -91,8 +91,8 @@
     [TestClass invokeStaticMethod:@"getFavoritePerson"
                        parameters:nil
                           success:^(id value) {
-                              STAssertNotNil(value, @"No value returned.");
-                              STAssertTrue([@"You" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                              XCTAssertNotNil(value, @"No value returned.");
+                              XCTAssertTrue([@"You" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                               ASYNC_TEST_SIGNAL
                           }
                           failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -106,8 +106,8 @@
     [test invokeMethod:@"getName"
             parameters:nil
                success:^(id value) {
-                   STAssertNotNil(value, @"No value returned.");
-                   STAssertTrue([@"somename" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                   XCTAssertNotNil(value, @"No value returned.");
+                   XCTAssertTrue([@"somename" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                    ASYNC_TEST_SIGNAL
                }
                failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -121,8 +121,8 @@
     [test invokeMethod:@"greet"
             parameters:@{ @"other": @"othername" }
                success:^(id value) {
-                   STAssertNotNil(value, @"No value returned.");
-                   STAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                   XCTAssertNotNil(value, @"No value returned.");
+                   XCTAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                    ASYNC_TEST_SIGNAL
                }
                failure:ASYNC_TEST_FAILURE_BLOCK];

--- a/SLRemotingTests/SLRESTAdapterTests.h
+++ b/SLRemotingTests/SLRESTAdapterTests.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2013 StrongLoop. All rights reserved.
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface SLRESTAdapterTests : SenTestCase
+@interface SLRESTAdapterTests : XCTestCase
 
 @end

--- a/SLRemotingTests/SLRESTAdapterTests.m
+++ b/SLRemotingTests/SLRESTAdapterTests.m
@@ -37,8 +37,8 @@
     [adapter invokeStaticMethod:@"simple.getSecret"
                      parameters:nil
                         success:^(id value) {
-                            STAssertNotNil(value, @"No value returned.");
-                            STAssertTrue([@"shhh!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                            XCTAssertNotNil(value, @"No value returned.");
+                            XCTAssertTrue([@"shhh!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                             ASYNC_TEST_SIGNAL
                         }
                         failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -50,8 +50,8 @@
     [adapter invokeStaticMethod:@"simple.transform"
                      parameters:@{ @"str": @"somevalue" }
                         success:^(id value) {
-                            STAssertNotNil(value, @"No value returned.");
-                            STAssertTrue([@"transformed: somevalue" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                            XCTAssertNotNil(value, @"No value returned.");
+                            XCTAssertTrue([@"transformed: somevalue" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                             ASYNC_TEST_SIGNAL
                         }
                         failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -64,8 +64,8 @@
             constructorParameters:@{ @"name": @"somename" }
                        parameters:nil
                           success:^(id value) {
-                              STAssertNotNil(value, @"No value returned.");
-                              STAssertTrue([@"somename" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                              XCTAssertNotNil(value, @"No value returned.");
+                              XCTAssertTrue([@"somename" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                               ASYNC_TEST_SIGNAL
                           }
                           failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -78,8 +78,8 @@
             constructorParameters:@{ @"name": @"somename" }
                        parameters:@{ @"other": @"othername" }
                           success:^(id value) {
-                              STAssertNotNil(value, @"No value returned.");
-                              STAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                              XCTAssertNotNil(value, @"No value returned.");
+                              XCTAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                               ASYNC_TEST_SIGNAL
                           }
                           failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -91,8 +91,8 @@
     [TestClass invokeStaticMethod:@"getFavoritePerson"
                        parameters:nil
                           success:^(id value) {
-                              STAssertNotNil(value, @"No value returned.");
-                              STAssertTrue([@"You" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                              XCTAssertNotNil(value, @"No value returned.");
+                              XCTAssertTrue([@"You" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                               ASYNC_TEST_SIGNAL
                           }
                           failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -106,8 +106,8 @@
     [test invokeMethod:@"getName"
             parameters:nil
                success:^(id value) {
-                   STAssertNotNil(value, @"No value returned.");
-                   STAssertTrue([@"somename" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                   XCTAssertNotNil(value, @"No value returned.");
+                   XCTAssertTrue([@"somename" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                    ASYNC_TEST_SIGNAL
                }
                failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -121,8 +121,8 @@
     [test invokeMethod:@"greet"
             parameters:@{ @"other": @"othername" }
                success:^(id value) {
-                   STAssertNotNil(value, @"No value returned.");
-                   STAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                   XCTAssertNotNil(value, @"No value returned.");
+                   XCTAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                    ASYNC_TEST_SIGNAL
                }
                failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -140,8 +140,8 @@
                             NSData *data =
                                 [outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
                             const unsigned char *bytes = [data bytes];
-                            STAssertTrue(bytes[0] == 1 && bytes[1] == 2 && bytes[2] == 3,
-                                         @"Incorrect binary data returned.");
+                            XCTAssertTrue(bytes[0] == 1 && bytes[1] == 2 && bytes[2] == 3,
+                                          @"Incorrect binary data returned.");
                             ASYNC_TEST_SIGNAL
                         }
                         failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -160,8 +160,8 @@
                               NSData *data =
                                 [outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
                               const unsigned char *bytes = [data bytes];
-                              STAssertTrue(bytes[0] == 4 && bytes[1] == 5 && bytes[2] == 6,
-                                           @"Incorrect binary data returned.");
+                              XCTAssertTrue(bytes[0] == 4 && bytes[1] == 5 && bytes[2] == 6,
+                                            @"Incorrect binary data returned.");
                               ASYNC_TEST_SIGNAL
                           }
                           failure:ASYNC_TEST_FAILURE_BLOCK];

--- a/SLRemotingTests/SLRESTContractTests.h
+++ b/SLRemotingTests/SLRESTContractTests.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2013 StrongLoop. All rights reserved.
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface SLRESTContractTests : SenTestCase
+@interface SLRESTContractTests : XCTestCase
 
 @end

--- a/SLRemotingTests/SLRESTContractTests.m
+++ b/SLRemotingTests/SLRESTContractTests.m
@@ -51,10 +51,10 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
     [child addItem:[SLRESTContractItem itemWithPattern:@"/new/route" verb:@"POST"] forMethod:@"new.route"];
 
     [parent addItemsFromContract:child];
-    STAssertTrue([[parent urlForMethod:@"test.route" parameters:@{}] isEqualToString:@"/test/route"], @"Wrong URL.");
-    STAssertTrue([[parent verbForMethod:@"test.route"] isEqualToString:@"GET"], @"Wrong verb.");
-    STAssertTrue([[parent urlForMethod:@"new.route" parameters:@{}] isEqualToString:@"/new/route"], @"Wrong URL.");
-    STAssertTrue([[parent verbForMethod:@"new.route"] isEqualToString:@"POST"], @"Wrong verb.");
+    XCTAssertTrue([[parent urlForMethod:@"test.route" parameters:@{}] isEqualToString:@"/test/route"], @"Wrong URL.");
+    XCTAssertTrue([[parent verbForMethod:@"test.route"] isEqualToString:@"GET"], @"Wrong verb.");
+    XCTAssertTrue([[parent urlForMethod:@"new.route" parameters:@{}] isEqualToString:@"/new/route"], @"Wrong URL.");
+    XCTAssertTrue([[parent verbForMethod:@"new.route"] isEqualToString:@"POST"], @"Wrong verb.");
 }
 
 - (void)testGet {
@@ -62,8 +62,8 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
     [adapter invokeStaticMethod:@"contract.getSecret"
                      parameters:nil
                         success:^(id value) {
-                            STAssertNotNil(value, @"No value returned.");
-                            STAssertTrue([@"shhh!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                            XCTAssertNotNil(value, @"No value returned.");
+                            XCTAssertTrue([@"shhh!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                             ASYNC_TEST_SIGNAL
                         }
                         failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -75,8 +75,8 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
     [adapter invokeStaticMethod:@"contract.transform"
                      parameters:@{ @"str": @"somevalue" }
                         success:^(id value) {
-                            STAssertNotNil(value, @"No value returned.");
-                            STAssertTrue([@"transformed: somevalue" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                            XCTAssertNotNil(value, @"No value returned.");
+                            XCTAssertTrue([@"transformed: somevalue" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                             ASYNC_TEST_SIGNAL
                         }
                         failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -89,8 +89,8 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
             constructorParameters:@{ @"name": @"somename" }
                        parameters:nil
                           success:^(id value) {
-                              STAssertNotNil(value, @"No value returned.");
-                              STAssertTrue([@"somename" isEqualToString:value[@"data"]], [NSString stringWithFormat:@"Incorrect value returned: %@", value]);
+                              XCTAssertNotNil(value, @"No value returned.");
+                              XCTAssertTrue([@"somename" isEqualToString:value[@"data"]], @"Incorrect value returned: %@", value);
                               ASYNC_TEST_SIGNAL
                           }
                           failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -103,8 +103,8 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
             constructorParameters:@{ @"name": @"somename" }
                        parameters:@{ @"other": @"othername" }
                           success:^(id value) {
-                              STAssertNotNil(value, @"No value returned.");
-                              STAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], [NSString stringWithFormat:@"Incorrect value returned: %@", value]);
+                              XCTAssertNotNil(value, @"No value returned.");
+                              XCTAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], @"Incorrect value returned: %@", value);
                               ASYNC_TEST_SIGNAL
                           }
                           failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -116,8 +116,8 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
     [TestClass invokeStaticMethod:@"getFavoritePerson"
                        parameters:nil
                           success:^(id value) {
-                              STAssertNotNil(value, @"No value returned.");
-                              STAssertTrue([@"You" isEqualToString:value[@"data"]], [NSString stringWithFormat:@"Incorrect value returned: %@", value]);
+                              XCTAssertNotNil(value, @"No value returned.");
+                              XCTAssertTrue([@"You" isEqualToString:value[@"data"]], @"Incorrect value returned: %@", value);
                               ASYNC_TEST_SIGNAL
                           }
                           failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -131,8 +131,8 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
     [test invokeMethod:@"getName"
             parameters:nil
                success:^(id value) {
-                   STAssertNotNil(value, @"No value returned.");
-                   STAssertTrue([@"somename" isEqualToString:value[@"data"]], [NSString stringWithFormat:@"Incorrect value returned: %@", value]);
+                   XCTAssertNotNil(value, @"No value returned.");
+                   XCTAssertTrue([@"somename" isEqualToString:value[@"data"]], @"Incorrect value returned: %@", value);
                    ASYNC_TEST_SIGNAL
                }
                failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -146,8 +146,8 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
     [test invokeMethod:@"greet"
             parameters:@{ @"other": @"othername" }
                success:^(id value) {
-                   STAssertNotNil(value, @"No value returned.");
-                   STAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], [NSString stringWithFormat:@"Incorrect value returned: %@", value]);
+                   XCTAssertNotNil(value, @"No value returned.");
+                   XCTAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], @"Incorrect value returned: %@", value);
                    ASYNC_TEST_SIGNAL
                }
                failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -164,8 +164,8 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
     [customAdapter invokeStaticMethod:@"contract.getAuthorizationHeader"
                            parameters:nil
                               success:^(id value) {
-                                  STAssertNotNil(value, @"No value returned.");
-                                  STAssertTrue([@"auth-token" isEqualToString:value[@"data"]], @"Incorrect value returned.");
+                                  XCTAssertNotNil(value, @"No value returned.");
+                                  XCTAssertTrue([@"auth-token" isEqualToString:value[@"data"]], @"Incorrect value returned.");
                                   ASYNC_TEST_SIGNAL
                               }
                               failure:ASYNC_TEST_FAILURE_BLOCK];


### PR DESCRIPTION
These changes add support to compile a macOSX library. SenTestingKit doesn't seem to be available anymore with the latest MacOS sdk so I converted the unit tests to use the more recent XCTest framework (which works on iOS and MacOS). All unit tests pass on iOS and MacOS.
I had to disable push notifications for OSX.