### PR TITLE
Intorduce LB 2.0 Persisted Model support

### DIFF
--- a/LoopBack.xcodeproj/project.pbxproj
+++ b/LoopBack.xcodeproj/project.pbxproj
@@ -87,13 +87,13 @@
 		47C48BDB1962123900995044 /* SLRESTAdapterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC91962123900995044 /* SLRESTAdapterTests.m */; };
 		47C48BDC1962123900995044 /* SLRESTContractTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BCB1962123900995044 /* SLRESTContractTests.m */; };
 		47D47194196DF4A1002E2358 /* SLRESTAdapterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC91962123900995044 /* SLRESTAdapterTests.m */; };
-		47D47196196DF4A1002E2358 /* LBModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2213A17722BAB00B7CB63 /* LBModelTests.m */; };
+		47D47196196DF4A1002E2358 /* LBPersistedModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2213A17722BAB00B7CB63 /* LBPersistedModelTests.m */; };
 		47D47197196DF4A1002E2358 /* SLRESTContractTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BCB1962123900995044 /* SLRESTContractTests.m */; };
 		47D47198196DF4A1002E2358 /* LBContainerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A201518A56BA5006772C8 /* LBContainerTests.m */; };
 		47D47199196DF4A1002E2358 /* LBUserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A201718A57CCD006772C8 /* LBUserTests.m */; };
 		47D4719A196DF4A1002E2358 /* SLRESTAdapterSSLTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC71962123900995044 /* SLRESTAdapterSSLTests.m */; };
 		47D4719B196DF4A1002E2358 /* SLRESTAdapterNonRootTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C48BC61962123900995044 /* SLRESTAdapterNonRootTests.m */; };
-		47D4719C196DF4A1002E2358 /* LBModelSubclassingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2214117725A7F00B7CB63 /* LBModelSubclassingTests.m */; };
+		47D4719C196DF4A1002E2358 /* LBPersistedModelSubclassingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2214117725A7F00B7CB63 /* LBPersistedModelSubclassingTests.m */; };
 		47D4719F196DF4A1002E2358 /* LBInstallationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4769FF08184D6F4F00E5152C /* LBInstallationTests.m */; };
 		47D471A0196DF4A1002E2358 /* LBFileTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A201A18A5856F006772C8 /* LBFileTests.m */; };
 		47D471A7196DF4A1002E2358 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220FA17722AE800B7CB63 /* Foundation.framework */; };
@@ -107,18 +107,25 @@
 		895B41831AB16D6B0000A9D7 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B278D4A187B584A00FFC135 /* SystemConfiguration.framework */; };
 		8973753E1AB2A60A00FB31A2 /* SLStreamParam.h in Headers */ = {isa = PBXBuildFile; fileRef = 8973753C1AB2A60A00FB31A2 /* SLStreamParam.h */; };
 		8973753F1AB2A60A00FB31A2 /* SLStreamParam.m in Sources */ = {isa = PBXBuildFile; fileRef = 8973753D1AB2A60A00FB31A2 /* SLStreamParam.m */; };
+		89C410341B4D4B0200B2ED51 /* LBPersistedModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 89C410321B4D4B0200B2ED51 /* LBPersistedModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		89C410351B4D4B0200B2ED51 /* LBPersistedModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 89C410331B4D4B0200B2ED51 /* LBPersistedModel.m */; };
 		89D3DB0E1AB174F1005A1B90 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BB51962123900995044 /* InfoPlist.strings */; };
 		89D3DB0F1AB174F1005A1B90 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 47C48BB51962123900995044 /* InfoPlist.strings */; };
 		89EB399D1AB16ED700B1EB9D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2214317725DAB00B7CB63 /* UIKit.framework */; };
 		89EB399E1AB16ED800B1EB9D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2214317725DAB00B7CB63 /* UIKit.framework */; };
 		89EB399F1AB16ED900B1EB9D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D2214317725DAB00B7CB63 /* UIKit.framework */; };
+		89F4F36C1B53E6A80070D8EB /* LBModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89F4F36B1B53E6A80070D8EB /* LBModelTests.m */; };
+		89F4F36D1B53E6A80070D8EB /* LBModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89F4F36B1B53E6A80070D8EB /* LBModelTests.m */; };
+		89F4F36E1B53E6DE0070D8EB /* LBModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89F4F36B1B53E6A80070D8EB /* LBModelTests.m */; };
+		89F4F36F1B546D0B0070D8EB /* LBPersistedModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 89C410331B4D4B0200B2ED51 /* LBPersistedModel.m */; };
+		89F4F3701B546D170070D8EB /* LBPersistedModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 89C410321B4D4B0200B2ED51 /* LBPersistedModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3D220FB17722AE800B7CB63 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220FA17722AE800B7CB63 /* Foundation.framework */; };
 		B3D2210D17722AE800B7CB63 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220FA17722AE800B7CB63 /* Foundation.framework */; };
 		B3D2211017722AE800B7CB63 /* libLoopBack.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D220F717722AE800B7CB63 /* libLoopBack.a */; };
 		B3D2211617722AE800B7CB63 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = B3D2211417722AE800B7CB63 /* InfoPlist.strings */; };
 		B3D2212417722B1700B7CB63 /* LBModel.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2212317722B1700B7CB63 /* LBModel.m */; };
-		B3D2213B17722BAB00B7CB63 /* LBModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2213A17722BAB00B7CB63 /* LBModelTests.m */; };
-		B3D2214217725A7F00B7CB63 /* LBModelSubclassingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2214117725A7F00B7CB63 /* LBModelSubclassingTests.m */; };
+		B3D2213B17722BAB00B7CB63 /* LBPersistedModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2213A17722BAB00B7CB63 /* LBPersistedModelTests.m */; };
+		B3D2214217725A7F00B7CB63 /* LBPersistedModelSubclassingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2214117725A7F00B7CB63 /* LBPersistedModelSubclassingTests.m */; };
 		B3D2214A1773766800B7CB63 /* LBRESTAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D221491773766800B7CB63 /* LBRESTAdapter.m */; };
 		B3DFA5AD17970AB700F656D7 /* LoopBack.h in Headers */ = {isa = PBXBuildFile; fileRef = B3D220FF17722AE800B7CB63 /* LoopBack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3DFA5AE17970ABD00F656D7 /* LBModel.h in Headers */ = {isa = PBXBuildFile; fileRef = B3D2212217722B1700B7CB63 /* LBModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -180,8 +187,8 @@
 		E4C9BC7D1AD6FC7000D70046 /* LBInstallationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4769FF08184D6F4F00E5152C /* LBInstallationTests.m */; };
 		E4C9BC7E1AD6FC9B00D70046 /* LBContainerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A201518A56BA5006772C8 /* LBContainerTests.m */; };
 		E4C9BC7F1AD6FCA300D70046 /* LBFileTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A201A18A5856F006772C8 /* LBFileTests.m */; };
-		E4C9BC801AD6FCA800D70046 /* LBModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2213A17722BAB00B7CB63 /* LBModelTests.m */; };
-		E4C9BC811AD6FCAD00D70046 /* LBModelSubclassingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2214117725A7F00B7CB63 /* LBModelSubclassingTests.m */; };
+		E4C9BC801AD6FCA800D70046 /* LBPersistedModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2213A17722BAB00B7CB63 /* LBPersistedModelTests.m */; };
+		E4C9BC811AD6FCAD00D70046 /* LBPersistedModelSubclassingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3D2214117725A7F00B7CB63 /* LBPersistedModelSubclassingTests.m */; };
 		E4C9BC821AD6FCB300D70046 /* LBUserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A201718A57CCD006772C8 /* LBUserTests.m */; };
 		E4C9BC841AD7005E00D70046 /* LBInstallation.m in Sources */ = {isa = PBXBuildFile; fileRef = 47AD031118491DA700F724C8 /* LBInstallation.m */; };
 /* End PBXBuildFile section */
@@ -294,12 +301,16 @@
 		47F8E812185B7A4E0088BB73 /* LBPushNotification.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBPushNotification.m; sourceTree = "<group>"; };
 		8973753C1AB2A60A00FB31A2 /* SLStreamParam.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SLStreamParam.h; sourceTree = "<group>"; };
 		8973753D1AB2A60A00FB31A2 /* SLStreamParam.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLStreamParam.m; sourceTree = "<group>"; };
+		89C410321B4D4B0200B2ED51 /* LBPersistedModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LBPersistedModel.h; sourceTree = "<group>"; };
+		89C410331B4D4B0200B2ED51 /* LBPersistedModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBPersistedModel.m; sourceTree = "<group>"; };
 		89D3C9521AB17258005A1B90 /* index.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = index.js; sourceTree = "<group>"; };
 		89D3DB001AB17263005A1B90 /* package.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = package.json; sourceTree = "<group>"; };
 		89D3DB031AB17263005A1B90 /* f1.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = f1.txt; sourceTree = "<group>"; };
 		89D3DB041AB17263005A1B90 /* f1_downloaded.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = f1_downloaded.txt; sourceTree = "<group>"; };
 		89D3DB051AB17263005A1B90 /* uploadTest.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = uploadTest.txt; sourceTree = "<group>"; };
 		89D3DB071AB17263005A1B90 /* f2.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = f2.txt; sourceTree = "<group>"; };
+		89F4F36A1B53E6A80070D8EB /* LBModelTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LBModelTests.h; sourceTree = "<group>"; };
+		89F4F36B1B53E6A80070D8EB /* LBModelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBModelTests.m; sourceTree = "<group>"; };
 		B3D220F717722AE800B7CB63 /* libLoopBack.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libLoopBack.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3D220FA17722AE800B7CB63 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		B3D220FE17722AE800B7CB63 /* LoopBack-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LoopBack-Prefix.pch"; sourceTree = "<group>"; };
@@ -309,10 +320,10 @@
 		B3D2211517722AE800B7CB63 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B3D2212217722B1700B7CB63 /* LBModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LBModel.h; sourceTree = "<group>"; };
 		B3D2212317722B1700B7CB63 /* LBModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBModel.m; sourceTree = "<group>"; };
-		B3D2213917722BAB00B7CB63 /* LBModelTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LBModelTests.h; sourceTree = "<group>"; };
-		B3D2213A17722BAB00B7CB63 /* LBModelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBModelTests.m; sourceTree = "<group>"; };
-		B3D2214017725A7F00B7CB63 /* LBModelSubclassingTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LBModelSubclassingTests.h; sourceTree = "<group>"; };
-		B3D2214117725A7F00B7CB63 /* LBModelSubclassingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBModelSubclassingTests.m; sourceTree = "<group>"; };
+		B3D2213917722BAB00B7CB63 /* LBPersistedModelTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LBPersistedModelTests.h; sourceTree = "<group>"; };
+		B3D2213A17722BAB00B7CB63 /* LBPersistedModelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBPersistedModelTests.m; sourceTree = "<group>"; };
+		B3D2214017725A7F00B7CB63 /* LBPersistedModelSubclassingTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LBPersistedModelSubclassingTests.h; sourceTree = "<group>"; };
+		B3D2214117725A7F00B7CB63 /* LBPersistedModelSubclassingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBPersistedModelSubclassingTests.m; sourceTree = "<group>"; };
 		B3D2214317725DAB00B7CB63 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		B3D221481773766800B7CB63 /* LBRESTAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LBRESTAdapter.h; sourceTree = "<group>"; };
 		B3D221491773766800B7CB63 /* LBRESTAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LBRESTAdapter.m; sourceTree = "<group>"; };
@@ -566,6 +577,8 @@
 				B3D220FF17722AE800B7CB63 /* LoopBack.h */,
 				B3D2212217722B1700B7CB63 /* LBModel.h */,
 				B3D2212317722B1700B7CB63 /* LBModel.m */,
+				89C410321B4D4B0200B2ED51 /* LBPersistedModel.h */,
+				89C410331B4D4B0200B2ED51 /* LBPersistedModel.m */,
 				B3D221481773766800B7CB63 /* LBRESTAdapter.h */,
 				B3D221491773766800B7CB63 /* LBRESTAdapter.m */,
 				47AD031018491DA700F724C8 /* LBInstallation.h */,
@@ -596,10 +609,12 @@
 		B3D2211117722AE800B7CB63 /* LoopBackTests */ = {
 			isa = PBXGroup;
 			children = (
-				B3D2213917722BAB00B7CB63 /* LBModelTests.h */,
-				B3D2213A17722BAB00B7CB63 /* LBModelTests.m */,
-				B3D2214017725A7F00B7CB63 /* LBModelSubclassingTests.h */,
-				B3D2214117725A7F00B7CB63 /* LBModelSubclassingTests.m */,
+				89F4F36A1B53E6A80070D8EB /* LBModelTests.h */,
+				89F4F36B1B53E6A80070D8EB /* LBModelTests.m */,
+				B3D2213917722BAB00B7CB63 /* LBPersistedModelTests.h */,
+				B3D2213A17722BAB00B7CB63 /* LBPersistedModelTests.m */,
+				B3D2214017725A7F00B7CB63 /* LBPersistedModelSubclassingTests.h */,
+				B3D2214117725A7F00B7CB63 /* LBPersistedModelSubclassingTests.m */,
 				4769FF07184D6F4F00E5152C /* LBInstallationTests.h */,
 				4769FF08184D6F4F00E5152C /* LBInstallationTests.m */,
 				0B3A201918A57D55006772C8 /* LBUserTests.h */,
@@ -668,6 +683,7 @@
 				47C48BAC1962120E00995044 /* SLRemoting-Prefix.pch in Headers */,
 				47C48BA21962120E00995044 /* SLAFURLConnectionOperation.h in Headers */,
 				B3DFA5AE17970ABD00F656D7 /* LBModel.h in Headers */,
+				89C410341B4D4B0200B2ED51 /* LBPersistedModel.h in Headers */,
 				B3DFA5AF17970ABD00F656D7 /* LBRESTAdapter.h in Headers */,
 				47C48BA41962120E00995044 /* SLAFXMLRequestOperation.h in Headers */,
 				0B8022DF18A2F1BA00AF845E /* LBContainer.h in Headers */,
@@ -720,6 +736,7 @@
 				E4C9BC571AD6FB9A00D70046 /* SLAFPropertyListRequestOperation.h in Headers */,
 				E4C9BC611AD6FBC500D70046 /* SLObject.h in Headers */,
 				E4C9BC5F1AD6FBBE00D70046 /* SLAdapter.h in Headers */,
+				89F4F3701B546D170070D8EB /* LBPersistedModel.h in Headers */,
 				E4C9BC6E1AD6FC0800D70046 /* LoopBack.h in Headers */,
 				E4C9BC651AD6FBDB00D70046 /* SLRemotingUtils.h in Headers */,
 				E4C9BC631AD6FBD200D70046 /* SLRemoting-Prefix.pch in Headers */,
@@ -974,15 +991,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				47D47194196DF4A1002E2358 /* SLRESTAdapterTests.m in Sources */,
-				47D47196196DF4A1002E2358 /* LBModelTests.m in Sources */,
+				47D47196196DF4A1002E2358 /* LBPersistedModelTests.m in Sources */,
 				47D47197196DF4A1002E2358 /* SLRESTContractTests.m in Sources */,
 				47D47198196DF4A1002E2358 /* LBContainerTests.m in Sources */,
 				47D47199196DF4A1002E2358 /* LBUserTests.m in Sources */,
 				47D4719A196DF4A1002E2358 /* SLRESTAdapterSSLTests.m in Sources */,
 				47D4719B196DF4A1002E2358 /* SLRESTAdapterNonRootTests.m in Sources */,
-				47D4719C196DF4A1002E2358 /* LBModelSubclassingTests.m in Sources */,
+				47D4719C196DF4A1002E2358 /* LBPersistedModelSubclassingTests.m in Sources */,
 				47D4719F196DF4A1002E2358 /* LBInstallationTests.m in Sources */,
 				47D471A0196DF4A1002E2358 /* LBFileTests.m in Sources */,
+				89F4F36E1B53E6DE0070D8EB /* LBModelTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1013,6 +1031,7 @@
 				47C48BA31962120E00995044 /* SLAFURLConnectionOperation.m in Sources */,
 				0B786866189B1C3300AB6782 /* LBFile.m in Sources */,
 				0B4F52AB18908089004F675A /* LBAccessToken.m in Sources */,
+				89C410351B4D4B0200B2ED51 /* LBPersistedModel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1021,15 +1040,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				47C48BDB1962123900995044 /* SLRESTAdapterTests.m in Sources */,
-				B3D2213B17722BAB00B7CB63 /* LBModelTests.m in Sources */,
+				B3D2213B17722BAB00B7CB63 /* LBPersistedModelTests.m in Sources */,
 				47C48BDC1962123900995044 /* SLRESTContractTests.m in Sources */,
 				0B3A201618A56BA5006772C8 /* LBContainerTests.m in Sources */,
 				0B3A201818A57CCD006772C8 /* LBUserTests.m in Sources */,
 				47C48BDA1962123900995044 /* SLRESTAdapterSSLTests.m in Sources */,
 				47C48BD91962123900995044 /* SLRESTAdapterNonRootTests.m in Sources */,
-				B3D2214217725A7F00B7CB63 /* LBModelSubclassingTests.m in Sources */,
+				B3D2214217725A7F00B7CB63 /* LBPersistedModelSubclassingTests.m in Sources */,
 				4769FF09184D6F4F00E5152C /* LBInstallationTests.m in Sources */,
 				0B3A201B18A5856F006772C8 /* LBFileTests.m in Sources */,
+				89F4F36C1B53E6A80070D8EB /* LBModelTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1056,6 +1076,7 @@
 				E4C9BC4F1AD6FB6E00D70046 /* SLAFHTTPRequestOperation.m in Sources */,
 				E4C9BC5C1AD6FBAE00D70046 /* SLAFXMLRequestOperation.m in Sources */,
 				E4C9BC581AD6FB9F00D70046 /* SLAFPropertyListRequestOperation.m in Sources */,
+				89F4F36F1B546D0B0070D8EB /* LBPersistedModel.m in Sources */,
 				E4C9BC7C1AD6FC6800D70046 /* LBFile.m in Sources */,
 				E4C9BC761AD6FC2B00D70046 /* LBUser.m in Sources */,
 				E4C9BC531AD6FB8400D70046 /* SLAFJSONRequestOperation.m in Sources */,
@@ -1066,8 +1087,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E4C9BC811AD6FCAD00D70046 /* LBModelSubclassingTests.m in Sources */,
-				E4C9BC801AD6FCA800D70046 /* LBModelTests.m in Sources */,
+				E4C9BC811AD6FCAD00D70046 /* LBPersistedModelSubclassingTests.m in Sources */,
+				E4C9BC801AD6FCA800D70046 /* LBPersistedModelTests.m in Sources */,
 				E4C9BC4A1AD6FB3900D70046 /* SLRESTAdapterTests.m in Sources */,
 				E4C9BC7F1AD6FCA300D70046 /* LBFileTests.m in Sources */,
 				E4C9BC7D1AD6FC7000D70046 /* LBInstallationTests.m in Sources */,
@@ -1076,6 +1097,7 @@
 				E4C9BC4B1AD6FB3D00D70046 /* SLRESTContractTests.m in Sources */,
 				E4C9BC491AD6FB3100D70046 /* SLRESTAdapterSSLTests.m in Sources */,
 				E4C9BC821AD6FCB300D70046 /* LBUserTests.m in Sources */,
+				89F4F36D1B53E6A80070D8EB /* LBModelTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LoopBack/LBAccessToken.h
+++ b/LoopBack/LBAccessToken.h
@@ -5,12 +5,12 @@
  * @copyright (c) 2014 StrongLoop. All rights reserved.
  */
 
-#import "LBModel.h"
+#import "LBPersistedModel.h"
 
 /**
  * An access token returned from the server for access control.
  */
-@interface LBAccessToken : LBModel
+@interface LBAccessToken : LBPersistedModel
 
 /** The user id associated with this access token. */
 @property (nonatomic, copy) NSString *userId;
@@ -20,7 +20,7 @@
 /**
  * A local representative of an access token on the server.
  */
-@interface LBAccessTokenRepository : LBModelRepository
+@interface LBAccessTokenRepository : LBPersistedModelRepository
 
 + (instancetype)repository;
 

--- a/LoopBack/LBContainer.h
+++ b/LoopBack/LBContainer.h
@@ -57,17 +57,24 @@ typedef void (^LBContainerDeleteSuccessBlock)();
 + (instancetype)repository;
 
 /**
+ * Blocks of this type are executed when
+ * LBContainerRepository::createContainerWithName:success:failure: is successful.
+ */
+typedef void (^LBContainerCreateSuccessBlock)(LBContainer* container);
+/**
  * Creates a container with the given name.
  *
  * @param  name       The container name.
  */
-- (LBContainer *)createContainerWithName:(NSString*)name;
+- (void)createContainerWithName:(NSString*)name
+                        success:(LBContainerCreateSuccessBlock)success
+                        failure:(SLFailureBlock)failure;
 
 /**
  * Blocks of this type are executed when
  * LBContainerRepository::getContainerWithName:success:failure: is successful.
  */
-typedef void (^LBGetContainerSuccessBlock)(LBContainer* container);
+typedef void (^LBContainerGetSuccessBlock)(LBContainer* container);
 /**
  * Attempts to get the named container from the server.
  *
@@ -76,21 +83,21 @@ typedef void (^LBGetContainerSuccessBlock)(LBContainer* container);
  * @param failure  The block to be executed when the get fails.
  */
 - (void)getContainerWithName:(NSString*)name
-                     success:(LBGetContainerSuccessBlock)success
+                     success:(LBContainerGetSuccessBlock)success
                      failure:(SLFailureBlock)failure;
 
 /**
  * Blocks of this type are executed when
  * LBContainerRepository::getAllContainersWithSuccess:failure: is successful.
  */
-typedef void (^LBGetAllContainersSuccessBlock)(NSArray* containers);
+typedef void (^LBContainerGetAllSuccessBlock)(NSArray* containers);
 /**
  * Returns all containers on the server.
  *
  * @param success  The block to be executed when the get is successful.
  * @param failure  The block to be executed when the get fails.
  */
-- (void)getAllContainersWithSuccess:(LBGetAllContainersSuccessBlock)success
+- (void)getAllContainersWithSuccess:(LBContainerGetAllSuccessBlock)success
                             failure:(SLFailureBlock)failure;
 
 @end

--- a/LoopBack/LBInstallation.h
+++ b/LoopBack/LBInstallation.h
@@ -1,10 +1,9 @@
 /**
  * @file LBInstallation.h
+ *
  * @author Raymond Feng
  * @copyright (c) 2013 StrongLoop. All rights reserved.
  */
-#ifndef LoopBack_LBInstallation_h
-#define LoopBack_LBInstallation_h
 
 #import "LoopBack.h"
 
@@ -16,7 +15,7 @@
  * connects the device token with application/user/timeZone/subscriptions for
  * the server to find devices of interest for push notifications.
  */
-@interface LBInstallation : LBModel
+@interface LBInstallation : LBPersistedModel
 
 /**
  * The app id received from LoopBack application signup.
@@ -101,7 +100,7 @@
 /**
  * Custom ModelRepository subclass for LBInstallation
  */
-@interface LBInstallationRepository : LBModelRepository
+@interface LBInstallationRepository : LBPersistedModelRepository
 
 /**
  * Get a singleton for LBInstallationRepository
@@ -110,4 +109,3 @@
 
 @end
 
-#endif

--- a/LoopBack/LBInstallation.m
+++ b/LoopBack/LBInstallation.m
@@ -1,3 +1,10 @@
+/**
+ * @file LBInstallation.m
+ *
+ * @author Raymond Feng
+ * @copyright (c) 2013 StrongLoop. All rights reserved.
+ */
+
 #import "LBInstallation.h"
 
 @interface LBInstallation ()

--- a/LoopBack/LBModel.h
+++ b/LoopBack/LBModel.h
@@ -9,13 +9,9 @@
 
 /**
  * A local representative of a single model instance on the server. The data is
- * immediately accessible locally, but can be saved, destroyed, etc. from the
- * server easily.
+ * immediately accessible locally.
  */
-@interface LBModel : SLObject
-
-/** All Models have a numerical `id` field. */
-@property (nonatomic, readonly, copy) id _id;
+@interface LBModel : SLObject 
 
 /**
  * Returns the value associated with a given key.
@@ -58,36 +54,6 @@
  */
 - (NSDictionary *)toDictionary;
 
-/**
- * Blocks of this type are executed when LBModel::saveWithSuccess:failure: is
- * successful.
- */
-typedef void (^LBModelSaveSuccessBlock)();
-/**
- * Saves the LBModel to the server.
- *
- * Calls `toDictionary` to determine which fields should be saved.
- *
- * @param success  The block to be executed when the save is successful.
- * @param failure  The block to be executed when the save fails.
- */
-- (void)saveWithSuccess:(LBModelSaveSuccessBlock)success
-                failure:(SLFailureBlock)failure;
-
-/**
- * Blocks of this type are executed when LBModel::destroyWithSuccess:failure: is
- * successful.
- */
-typedef void (^LBModelDestroySuccessBlock)();
-/**
- * Destroys the LBModel from the server.
- *
- * @param success  The block to be executed when the destroy is successful.
- * @param failure  The block to be executed when the destroy fails.
- */
-- (void)destroyWithSuccess:(LBModelDestroySuccessBlock)success
-                   failure:(SLFailureBlock)failure;
-
 @end
 
 /**
@@ -115,46 +81,5 @@ typedef void (^LBModelDestroySuccessBlock)();
  * @return            A new LBModel.
  */
 - (LBModel *)modelWithDictionary:(NSDictionary *)dictionary;
-
-//typedef void (^LBModelExistsSuccessBlock)(BOOL exists);
-//- (void)existsWithId:(id)_id
-//             success:(LBModelExistsSuccessBlock)success
-//             failure:(SLFailureBlock)failure;
-
-/**
- * Blocks of this type are executed when
- * LBModelRepository::findById:success:failure: is successful.
- */
-typedef void (^LBModelFindSuccessBlock)(LBModel *model);
-/**
- * Finds and downloads a single instance of this model type on and from the
- * server with the given id.
- *
- * @param _id      The id to search for.
- * @param success  The block to be executed when the destroy is successful.
- * @param failure  The block to be executed when the destroy fails.
- */
-- (void)findById:(id)_id
-           success:(LBModelFindSuccessBlock)success
-           failure:(SLFailureBlock)failure;
-
-/**
- * Blocks of this type are executed when
- * LBModelRepository::allWithSuccess:failure: is successful.
- */
-typedef void (^LBModelAllSuccessBlock)(NSArray *models);
-/**
- * Finds and downloads all models of this type on and from the server.
- *
- * @param success  The block to be executed when the destroy is successful.
- * @param failure  The block to be executed when the destroy fails.
- */
-- (void)allWithSuccess:(LBModelAllSuccessBlock)success
-               failure:(SLFailureBlock)failure;
-
-//typedef void (^LBModelFindOneSuccessBlock)(LBModel *model);
-//- (void)findOneWithFilter:(NSDictionary *)filter
-//                  success:(LBModelFindOneSuccessBlock)success
-//                  failure:(SLFailureBlock)failure;
 
 @end

--- a/LoopBack/LBPersistedModel.h
+++ b/LoopBack/LBPersistedModel.h
@@ -1,0 +1,102 @@
+/**
+ * @file LBPersistedModel.h
+ *
+ * @author Michael Schoonmaker
+ * @copyright (c) 2013 StrongLoop. All rights reserved.
+ */
+
+#import "LBModel.h"
+
+/**
+ * A local representative of a single persisted model instance on the server.
+ * The key difference from LBModel is that this implements the CRUD operation supports.
+ */
+@interface LBPersistedModel : LBModel
+
+/** All Models have a numerical `id` field. */
+@property (nonatomic, readonly, copy) id _id;
+
+/**
+ * Blocks of this type are executed when LBPersistedModel::saveWithSuccess:failure: is
+ * successful.
+ */
+typedef void (^LBPersistedModelSaveSuccessBlock)();
+/**
+ * Saves the LBPersistedModel to the server.
+ *
+ * Calls `toDictionary` to determine which fields should be saved.
+ *
+ * @param success  The block to be executed when the save is successful.
+ * @param failure  The block to be executed when the save fails.
+ */
+- (void)saveWithSuccess:(LBPersistedModelSaveSuccessBlock)success
+                failure:(SLFailureBlock)failure;
+
+/**
+ * Blocks of this type are executed when LBPersistedModel::destroyWithSuccess:failure: is
+ * successful.
+ */
+typedef void (^LBPersistedModelDestroySuccessBlock)();
+/**
+ * Destroys the LBPersistedModel from the server.
+ *
+ * @param success  The block to be executed when the destroy is successful.
+ * @param failure  The block to be executed when the destroy fails.
+ */
+- (void)destroyWithSuccess:(LBPersistedModelDestroySuccessBlock)success
+                   failure:(SLFailureBlock)failure;
+
+@end
+
+
+/**
+ * A local representative of a single model type on the server, encapsulating
+ * the name of the model type for easy LBPersistedModel creation, discovery, and
+ * management.
+ */
+@interface LBPersistedModelRepository : LBModelRepository
+
++ (instancetype)repository;
+
+//typedef void (^LBPersistedModelExistsSuccessBlock)(BOOL exists);
+//- (void)existsWithId:(id)_id
+//             success:(LBPersistedModelExistsSuccessBlock)success
+//             failure:(SLFailureBlock)failure;
+
+/**
+ * Blocks of this type are executed when
+ * LBModelRepository::findById:success:failure: is successful.
+ */
+typedef void (^LBPersistedModelFindSuccessBlock)(LBPersistedModel *model);
+/**
+ * Finds and downloads a single instance of this model type on and from the
+ * server with the given id.
+ *
+ * @param _id      The id to search for.
+ * @param success  The block to be executed when the destroy is successful.
+ * @param failure  The block to be executed when the destroy fails.
+ */
+- (void)findById:(id)_id
+         success:(LBPersistedModelFindSuccessBlock)success
+         failure:(SLFailureBlock)failure;
+
+/**
+ * Blocks of this type are executed when
+ * LBPersistedModelRepository::allWithSuccess:failure: is successful.
+ */
+typedef void (^LBPersistedModelAllSuccessBlock)(NSArray *models);
+/**
+ * Finds and downloads all models of this type on and from the server.
+ *
+ * @param success  The block to be executed when the destroy is successful.
+ * @param failure  The block to be executed when the destroy fails.
+ */
+- (void)allWithSuccess:(LBPersistedModelAllSuccessBlock)success
+               failure:(SLFailureBlock)failure;
+
+//typedef void (^LBPersistedModelFindOneSuccessBlock)(LBPersistedModel *model);
+//- (void)findOneWithFilter:(NSDictionary *)filter
+//                  success:(LBPersistedModelFindOneSuccessBlock)success
+//                  failure:(SLFailureBlock)failure;
+
+@end

--- a/LoopBack/LBPersistedModel.m
+++ b/LoopBack/LBPersistedModel.m
@@ -1,0 +1,117 @@
+/**
+ * @file LBPersistedModel.m
+ *
+ * @author Michael Schoonmaker
+ * @copyright (c) 2013 StrongLoop. All rights reserved.
+ */
+
+#import "LBPersistedModel.h"
+
+#import <objc/runtime.h>
+
+#define NSSelectorForSetter(key) NSSelectorFromString([NSString stringWithFormat:@"set%@:", [key stringByReplacingCharactersInRange:NSMakeRange(0,1) withString:[[key substringToIndex:1] capitalizedString]]])
+
+
+@interface LBPersistedModel() {
+    id __id;
+}
+
+- (void)setId:(id)_id;
+
+@end
+
+@implementation LBPersistedModel
+
+- (void)setId:(id)_id {
+    __id = _id;
+}
+
+- (NSDictionary *)toDictionary {
+    NSMutableDictionary *dict = (NSMutableDictionary *)[super toDictionary];
+    [dict removeObjectForKey:@"_id"];
+    [dict setValue:__id forKey:@"id"];
+
+    return dict;
+}
+
+- (void)saveWithSuccess:(LBPersistedModelSaveSuccessBlock)success
+                failure:(SLFailureBlock)failure {
+    [self invokeMethod:self._id ? @"save" : @"create"
+            parameters:[self toDictionary]
+               success:^(id value) {
+                   __id = [[value valueForKey:@"id"] copy];
+                   success();
+               }
+               failure:failure];
+}
+
+- (void)destroyWithSuccess:(LBPersistedModelDestroySuccessBlock)success
+                   failure:(SLFailureBlock)failure {
+    [self invokeMethod:@"remove"
+            parameters:[self toDictionary]
+               success:^(id value) {
+                   success();
+               }
+               failure:failure];
+}
+
+@end
+
+@implementation LBPersistedModelRepository
+
++ (instancetype)repository {
+    LBPersistedModelRepository *repository = [self repositoryWithClassName:@"persistentmodels"];
+    repository.modelClass = [LBPersistedModel class];
+    return repository;
+}
+
+- (SLRESTContract *)contract {
+    SLRESTContract *contract = [super contract];
+
+    [contract addItem:[SLRESTContractItem itemWithPattern:[NSString stringWithFormat:@"/%@", self.className] verb:@"POST"]
+            forMethod:[NSString stringWithFormat:@"%@.prototype.create", self.className]];
+    [contract addItem:[SLRESTContractItem itemWithPattern:[NSString stringWithFormat:@"/%@/:id", self.className] verb:@"PUT"]
+            forMethod:[NSString stringWithFormat:@"%@.prototype.save", self.className]];
+    [contract addItem:[SLRESTContractItem itemWithPattern:[NSString stringWithFormat:@"/%@/:id", self.className] verb:@"DELETE"]
+            forMethod:[NSString stringWithFormat:@"%@.prototype.remove", self.className]];
+
+    [contract addItem:[SLRESTContractItem itemWithPattern:[NSString stringWithFormat:@"/%@/:id", self.className] verb:@"GET"]
+            forMethod:[NSString stringWithFormat:@"%@.findById", self.className]];
+    [contract addItem:[SLRESTContractItem itemWithPattern:[NSString stringWithFormat:@"/%@", self.className] verb:@"GET"]
+            forMethod:[NSString stringWithFormat:@"%@.all", self.className]];
+
+    return contract;
+}
+
+- (void)findById:(id)_id
+         success:(LBPersistedModelFindSuccessBlock)success
+         failure:(SLFailureBlock)failure {
+    NSParameterAssert(_id);
+    [self invokeStaticMethod:@"findById"
+                  parameters:@{ @"id": _id }
+                     success:^(id value) {
+                         NSAssert([[value class] isSubclassOfClass:[NSDictionary class]], @"Received non-Dictionary: %@", value);
+                         success((LBPersistedModel*)[self modelWithDictionary:value]);
+                     } failure:failure];
+}
+
+- (void)allWithSuccess:(LBPersistedModelAllSuccessBlock)success
+               failure:(SLFailureBlock)failure {
+    [self invokeStaticMethod:@"all"
+                  parameters:@{}
+                     success:^(id value) {
+                         NSAssert([[value class] isSubclassOfClass:[NSArray class]], @"Received non-Array: %@", value);
+
+                         NSMutableArray *models = [NSMutableArray array];
+
+                         [value enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+                             [models addObject:[self modelWithDictionary:obj]];
+                         }];
+
+                         success(models);
+                     }
+                     failure:failure];
+}
+
+
+@end

--- a/LoopBack/LBPushNotification.h
+++ b/LoopBack/LBPushNotification.h
@@ -1,16 +1,14 @@
 /**
  * @file LBPushNotification.h
+ *
  * @author Raymond Feng
  * @copyright (c) 2013 StrongLoop. All rights reserved.
  */
 
-#ifndef LoopBack_LBPushNotification_h
-#define LoopBack_LBPushNotification_h
-
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#import <LoopBack/LoopBack.h>
+#import "LBRESTAdapter.h"
 
 /**
  @abstract Push Notification Type: Indicates in what state was app when received it (Foreground, Background, Terminated)
@@ -93,4 +91,3 @@ typedef enum LBPushNotificationType {
 
 @end
 
-#endif

--- a/LoopBack/LBPushNotification.m
+++ b/LoopBack/LBPushNotification.m
@@ -1,3 +1,10 @@
+/**
+ * @file LBPushNotification.m
+ *
+ * @author Raymond Feng
+ * @copyright (c) 2013 StrongLoop. All rights reserved.
+ */
+
 #import "LBPushNotification.h"
 #import "LBInstallation.h"
 

--- a/LoopBack/LBPushNotification.m
+++ b/LoopBack/LBPushNotification.m
@@ -20,6 +20,7 @@
 + (LBPushNotification *) application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
     // Let the device know we want to receive push notifications
+#ifdef __IPHONE_8_0
     if ([application respondsToSelector:@selector(registerUserNotificationSettings:)]) {
         // iOS 8 or later
         UIUserNotificationType types = UIUserNotificationTypeBadge |
@@ -29,7 +30,9 @@
                                                                                  categories:nil];
         [application registerUserNotificationSettings:settings];
         [application registerForRemoteNotifications];
-    } else {
+    } else
+#endif
+    {
         UIRemoteNotificationType types = UIRemoteNotificationTypeBadge |
                                          UIRemoteNotificationTypeSound |
                                          UIRemoteNotificationTypeAlert;

--- a/LoopBack/LBRESTAdapter.h
+++ b/LoopBack/LBRESTAdapter.h
@@ -8,6 +8,7 @@
 #import "SLRemoting.h"
 
 #import "LBModel.h"
+#import "LBPersistedModel.h"
 
 /**
  * An extension to the vanilla SLRESTAdapter to make working with LBModels
@@ -16,12 +17,15 @@
 @interface LBRESTAdapter : SLRESTAdapter
 
 /**
- * Returns a new LBModelRepository representing the named model type.
+ * Returns a new LBModelRepository or LBPersistedModelRepository representing the named model type.
  *
- * @param  name The model name.
- * @return      A new repository instance.
+ * @param  name       The model name.
+ * @param  persisted  A flag to specify `LBPersistedModelRepository` to be created.
+ *                    `NO` to create a `LBModelRepository`.
+ * @return            A new repository instance.
  */
-- (LBModelRepository *)repositoryWithModelName:(NSString *)name;
+
+- (LBModelRepository *)repositoryWithModelName:(NSString *)name persisted:(BOOL)persisted;
 
 /**
  * Returns a new LBModelRepository from the given subclass.

--- a/LoopBack/LBRESTAdapter.m
+++ b/LoopBack/LBRESTAdapter.m
@@ -34,10 +34,15 @@ static NSString * const DEFAULTS_ACCESSTOKEN_KEY = @"LBRESTAdapterAccessToken";
     [self saveAccessToken:accessToken];
 }
 
-- (LBModelRepository *)repositoryWithModelName:(NSString *)name {
+- (LBModelRepository *)repositoryWithModelName:(NSString *)name persisted:(BOOL)persisted {
     NSParameterAssert(name);
 
-    LBModelRepository *repository = [LBModelRepository repositoryWithClassName:name];
+    LBModelRepository *repository = nil;
+    if (persisted) {
+        repository = [LBPersistedModelRepository repositoryWithClassName:name];
+    } else {
+        repository = [LBModelRepository repositoryWithClassName:name];
+    }
     [self attachRepository:repository];
     return repository;
 }

--- a/LoopBack/LBUser.h
+++ b/LoopBack/LBUser.h
@@ -5,14 +5,14 @@
  * @copyright (c) 2014 StrongLoop. All rights reserved.
  */
 
-#import "LBModel.h"
+#import "LBPersistedModel.h"
 
 @class LBAccessToken;
 
 /**
  * A local representative of a user instance on the server.
  */
-@interface LBUser : LBModel
+@interface LBUser : LBPersistedModel
 
 @property (nonatomic, copy) NSString *email;
 @property (nonatomic, copy) NSString *password;
@@ -27,7 +27,7 @@
  * A local representative of the User type on the server, encapsulating
  * all User properties.
  */
-@interface LBUserRepository : LBModelRepository
+@interface LBUserRepository : LBPersistedModelRepository
 
 @property (nonatomic, readonly) NSString *currentUserId;
 @property (nonatomic, readonly) LBUser *cachedCurrentUser;

--- a/LoopBack/LoopBack.h
+++ b/LoopBack/LoopBack.h
@@ -6,6 +6,7 @@
  */
 
 #import "LBModel.h"
+#import "LBPersistedModel.h"
 #import "LBRESTAdapter.h"
 #import "LBInstallation.h"
 #if TARGET_OS_IPHONE

--- a/LoopBackTests/LBContainerTests.m
+++ b/LoopBackTests/LBContainerTests.m
@@ -68,8 +68,9 @@
 
 - (void)testCreate {
     ASYNC_TEST_START
-    LBContainer __block *container = [self.repository createContainerWithName:@"containerTest"];
-    [container saveWithSuccess:^{
+    [self.repository createContainerWithName:@"containerTest" success:^(LBContainer *container) {
+        XCTAssertNotNil(container, @"Container not found.");
+        XCTAssertEqualObjects(container.name, @"containerTest", @"Invalid name");
         ASYNC_TEST_SIGNAL
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END

--- a/LoopBackTests/LBInstallationTests.m
+++ b/LoopBackTests/LBInstallationTests.m
@@ -1,5 +1,5 @@
 //
-//  LBModelTests.m
+//  LBInstallationTests.m
 //  LoopBack
 //
 //  Created by Michael Schoonmaker on 6/19/13.
@@ -138,7 +138,7 @@ static id lastId = nil;
 - (void)testRemove {
     ASYNC_TEST_START
     [self.repository findById:lastId
-                      success:^(LBModel *model) {
+                      success:^(LBPersistedModel *model) {
                           [model destroyWithSuccess:^{
                               ASYNC_TEST_SIGNAL
                           } failure:ASYNC_TEST_FAILURE_BLOCK];

--- a/LoopBackTests/LBModelTests.h
+++ b/LoopBackTests/LBModelTests.h
@@ -2,8 +2,7 @@
 //  LBModelTests.h
 //  LoopBack
 //
-//  Created by Michael Schoonmaker on 6/19/13.
-//  Copyright (c) 2013 StrongLoop. All rights reserved.
+//  Copyright (c) 2015 StrongLoop. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/LoopBackTests/LBModelTests.m
+++ b/LoopBackTests/LBModelTests.m
@@ -2,16 +2,13 @@
 //  LBModelTests.m
 //  LoopBack
 //
-//  Created by Michael Schoonmaker on 6/19/13.
-//  Copyright (c) 2013 StrongLoop. All rights reserved.
+//  Copyright (c) 2015 StrongLoop. All rights reserved.
 //
 
 #import "LBModelTests.h"
 
 #import "LBModel.h"
 #import "LBRESTAdapter.h"
-
-static NSNumber *lastId;
 
 @interface LBModelTests()
 
@@ -21,113 +18,52 @@ static NSNumber *lastId;
 
 @implementation LBModelTests
 
-/**
- * Create the default test suite to control the order of test methods
- */
-+ (id)defaultTestSuite {
-    XCTestSuite *suite = [XCTestSuite testSuiteWithName:@"TestSuite for LBModel."];
-    [suite addTest:[self testCaseWithSelector:@selector(testCreate)]];
-    [suite addTest:[self testCaseWithSelector:@selector(testFind)]];
-    [suite addTest:[self testCaseWithSelector:@selector(testAll)]];
-    [suite addTest:[self testCaseWithSelector:@selector(testUpdate)]];
-    [suite addTest:[self testCaseWithSelector:@selector(testRemove)]];
-    return suite;
-}
-
-
 - (void)setUp {
     [super setUp];
 
     LBRESTAdapter *adapter = [LBRESTAdapter adapterWithURL:[NSURL URLWithString:@"http://localhost:3000"]];
-    self.repository = [adapter repositoryWithModelName:@"widgets"];
+    self.repository = (LBModelRepository*)[adapter repositoryWithModelName:@"widgets" persisted:NO];
 }
 
 - (void)tearDown {
     [super tearDown];
 }
 
-- (void)testCreate {
-    LBModel __block *model = [self.repository modelWithDictionary:@{ @"name": @"Foobar", @"bars": @1 }];
+- (void)testObjectForKeyedSubscript {
+    LBModel *model = [self.repository modelWithDictionary:@{ @"name": @"Foo", @"bars": @123 }];
 
-    XCTAssertEqualObjects(@"Foobar", model[@"name"], @"Invalid name.");
-    XCTAssertEqualObjects(@1, model[@"bars"], @"Invalid bars.");
-    XCTAssertNil(model._id, @"Invalid id");
+    XCTAssertEqualObjects(@"Foo", [model objectForKeyedSubscript:@"name"], @"Invalid name.");
+    XCTAssertEqualObjects(@123, [model objectForKeyedSubscript:@"bars"], @"Invalid bars.");
 
-    ASYNC_TEST_START
-    [model saveWithSuccess:^{
-        NSLog(@"Completed with: %@", model._id);
-        lastId = model._id;
-        XCTAssertNotNil(model._id, @"Invalid id");
-        ASYNC_TEST_SIGNAL
-    } failure:ASYNC_TEST_FAILURE_BLOCK];
-    ASYNC_TEST_END
+    // objectForKeyedSubscript: method enables the use of [key] notation to get the value
+    XCTAssertEqualObjects(@"Foo", model[@"name"], @"Invalid name.");
+    XCTAssertEqualObjects(@123, model[@"bars"], @"Invalid bars.");
 }
 
-- (void)testFind {
-    ASYNC_TEST_START
-    [self.repository findById:@2
-                       success:^(LBModel *model) {
-                           XCTAssertNotNil(model, @"No model found with ID 2");
-                           XCTAssertTrue([[model class] isSubclassOfClass:[LBModel class]], @"Invalid class.");
-                           XCTAssertEqualObjects(model[@"name"], @"Bar", @"Invalid name");
-                           XCTAssertEqualObjects(model[@"bars"], @1, @"Invalid bars");
-                           ASYNC_TEST_SIGNAL
-                       } failure:ASYNC_TEST_FAILURE_BLOCK];
-    ASYNC_TEST_END
+- (void)testSetObject {
+    LBModel *model = [self.repository modelWithDictionary:@{ @"name": @"Foo", @"bars": @123 }];
+
+    [model setObject:@"Bar" forKeyedSubscript:@"name"];
+    [model setObject:@456 forKeyedSubscript:@"bars"];
+
+    XCTAssertEqualObjects(@"Bar", model[@"name"], @"Invalid name.");
+    XCTAssertEqualObjects(@456, model[@"bars"], @"Invalid bars.");
+
+    // setObject:forKeyedSubscript: method enables the use of [key] notation to set a value
+    model[@"name"] = @"Baz";
+    model[@"bars"] = @789;
+
+    XCTAssertEqualObjects(@"Baz", model[@"name"], @"Invalid name.");
+    XCTAssertEqualObjects(@789, model[@"bars"], @"Invalid bars.");
 }
 
-- (void)testAll {
-    ASYNC_TEST_START
-    [self.repository allWithSuccess:^(NSArray *models) {
-        XCTAssertNotNil(models, @"No models returned.");
-        XCTAssertTrue([models count] >= 2, @"Invalid # of models returned: %lu", (unsigned long)[models count]);
-        XCTAssertTrue([[models[0] class] isSubclassOfClass:[LBModel class]], @"Invalid class.");
-        XCTAssertEqualObjects(models[0][@"name"], @"Foo", @"Invalid name");
-        XCTAssertEqualObjects(models[0][@"bars"], @0, @"Invalid bars");
-        XCTAssertEqualObjects(models[1][@"name"], @"Bar", @"Invalid name");
-        XCTAssertEqualObjects(models[1][@"bars"], @1, @"Invalid bars");
-        ASYNC_TEST_SIGNAL
-    } failure:ASYNC_TEST_FAILURE_BLOCK];
-    ASYNC_TEST_END
+- (void)testToDictionary {
+    NSDictionary *origDict = @{ @"name": @"Foo", @"bars": @123 };
+    LBModel *model = [self.repository modelWithDictionary:origDict];
+
+    NSDictionary *dict = [model toDictionary];
+
+    XCTAssertTrue([dict isEqual:origDict], @"Invalid dictionary");
 }
-
-- (void)testUpdate {
-    ASYNC_TEST_START
-    LBModelFindSuccessBlock verify = ^(LBModel *model) {
-        XCTAssertNotNil(model, @"No model found with ID 2");
-        XCTAssertEqualObjects(model[@"name"], @"Barfoo", @"Invalid name");
-        XCTAssertEqualObjects(model[@"bars"], @1, @"Invalid bars");
-
-        model[@"name"] = @"Bar";
-        [model saveWithSuccess:^{
-            ASYNC_TEST_SIGNAL
-        } failure:ASYNC_TEST_FAILURE_BLOCK];
-    };
-
-    LBModelSaveSuccessBlock findAgain = ^() {
-        [self.repository findById:@2 success:verify failure:ASYNC_TEST_FAILURE_BLOCK];
-    };
-
-    LBModelFindSuccessBlock update = ^(LBModel *model) {
-        XCTAssertNotNil(model, @"No model found with ID 2");
-        model[@"name"] = @"Barfoo";
-        [model saveWithSuccess:findAgain failure:ASYNC_TEST_FAILURE_BLOCK];
-    };
-
-    [self.repository findById:@2 success:update failure:ASYNC_TEST_FAILURE_BLOCK];
-    ASYNC_TEST_END
-}
-
-- (void)testRemove {
-    ASYNC_TEST_START
-    [self.repository findById:lastId
-                      success:^(LBModel *model) {
-                          [model destroyWithSuccess:^{
-                              ASYNC_TEST_SIGNAL
-                          } failure:ASYNC_TEST_FAILURE_BLOCK];
-                      } failure:ASYNC_TEST_FAILURE_BLOCK];
-    ASYNC_TEST_END
-}
-
 
 @end

--- a/LoopBackTests/LBPersistedModelSubclassingTests.h
+++ b/LoopBackTests/LBPersistedModelSubclassingTests.h
@@ -1,5 +1,5 @@
 //
-//  LBInstallationTests.h
+//  LBPersistedModelSubclassingTest.h
 //  LoopBack
 //
 //  Created by Michael Schoonmaker on 6/19/13.
@@ -8,6 +8,6 @@
 
 #import <XCTest/XCTest.h>
 
-@interface LBInstallationTests : XCTestCase
+@interface LBPersistedModelSubclassingTests : XCTestCase
 
 @end

--- a/LoopBackTests/LBPersistedModelSubclassingTests.m
+++ b/LoopBackTests/LBPersistedModelSubclassingTests.m
@@ -1,19 +1,19 @@
 //
-//  LBModelSubclassingTests.m
+//  LBPersistedModelSubclassingTest.m
 //  LoopBack
 //
 //  Created by Michael Schoonmaker on 6/19/13.
 //  Copyright (c) 2013 StrongLoop. All rights reserved.
 //
 
-#import "LBModelSubclassingTests.h"
+#import "LBPersistedModelSubclassingTests.h"
 
 #import "LBModel.h"
 #import "LBRESTAdapter.h"
 
 static NSNumber *lastId;
 
-@interface Widget : LBModel
+@interface Widget : LBPersistedModel
 
 @property (nonatomic, copy) NSString *name;
 @property (nonatomic) NSNumber *bars;
@@ -24,7 +24,7 @@ static NSNumber *lastId;
 
 @end
 
-@interface WidgetRepository : LBModelRepository
+@interface WidgetRepository : LBPersistedModelRepository
 + (instancetype)repository;
 
 @end
@@ -37,13 +37,13 @@ static NSNumber *lastId;
 
 @end
 
-@interface LBModelSubclassingTests()
+@interface LBPersistedModelSubclassingTests()
 
 @property (nonatomic) WidgetRepository *repository;
 
 @end
 
-@implementation LBModelSubclassingTests
+@implementation LBPersistedModelSubclassingTests
 
 /**
  * Create the default test suite to control the order of test methods
@@ -115,7 +115,7 @@ static NSNumber *lastId;
 
 - (void)testUpdate {
     ASYNC_TEST_START
-    LBModelFindSuccessBlock verify = ^(LBModel *model) {
+    LBPersistedModelFindSuccessBlock verify = ^(LBPersistedModel *model) {
         XCTAssertNotNil(model, @"No model found with ID 2");
         XCTAssertTrue([[model class] isSubclassOfClass:[Widget class]], @"Invalid class.");
         XCTAssertEqualObjects(((Widget *)model).name, @"Barfoo", @"Invalid name");
@@ -127,11 +127,11 @@ static NSNumber *lastId;
         } failure:ASYNC_TEST_FAILURE_BLOCK];
     };
 
-    LBModelSaveSuccessBlock findAgain = ^() {
+    LBPersistedModelSaveSuccessBlock findAgain = ^() {
         [self.repository findById:@2 success:verify failure:ASYNC_TEST_FAILURE_BLOCK];
     };
 
-    LBModelFindSuccessBlock update = ^(LBModel *model) {
+    LBPersistedModelFindSuccessBlock update = ^(LBPersistedModel *model) {
         XCTAssertNotNil(model, @"No model found with ID 2");
         ((Widget *)model).name = @"Barfoo";
         [model saveWithSuccess:findAgain failure:ASYNC_TEST_FAILURE_BLOCK];
@@ -144,7 +144,7 @@ static NSNumber *lastId;
 - (void)testRemove {
     ASYNC_TEST_START
     [self.repository findById:lastId
-                      success:^(LBModel *model) {
+                      success:^(LBPersistedModel *model) {
                           [model destroyWithSuccess:^{
                               ASYNC_TEST_SIGNAL
                           } failure:ASYNC_TEST_FAILURE_BLOCK];

--- a/LoopBackTests/LBPersistedModelTests.h
+++ b/LoopBackTests/LBPersistedModelTests.h
@@ -1,5 +1,5 @@
 //
-//  LBModelSubclassingTests.h
+//  LBPersistedModelTests.h
 //  LoopBack
 //
 //  Created by Michael Schoonmaker on 6/19/13.
@@ -8,6 +8,6 @@
 
 #import <XCTest/XCTest.h>
 
-@interface LBModelSubclassingTests : XCTestCase
+@interface LBPersistedModelTests : XCTestCase
 
 @end

--- a/LoopBackTests/LBPersistedModelTests.m
+++ b/LoopBackTests/LBPersistedModelTests.m
@@ -1,0 +1,134 @@
+//
+//  LBPersistedModelTests.m
+//  LoopBack
+//
+//  Created by Michael Schoonmaker on 6/19/13.
+//  Copyright (c) 2013 StrongLoop. All rights reserved.
+//
+
+#import "LBPersistedModelTests.h"
+
+#import "LBPersistedModel.h"
+#import "LBRESTAdapter.h"
+
+static NSNumber *lastId;
+
+@interface LBPersistedModelTests()
+
+@property (nonatomic) LBPersistedModelRepository *repository;
+
+@end
+
+@implementation LBPersistedModelTests
+
+/**
+ * Create the default test suite to control the order of test methods
+ */
++ (id)defaultTestSuite {
+    XCTestSuite *suite = [XCTestSuite testSuiteWithName:@"TestSuite for LBModel."];
+    [suite addTest:[self testCaseWithSelector:@selector(testCreate)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testFind)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testAll)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testUpdate)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testRemove)]];
+    return suite;
+}
+
+
+- (void)setUp {
+    [super setUp];
+
+    LBRESTAdapter *adapter = [LBRESTAdapter adapterWithURL:[NSURL URLWithString:@"http://localhost:3000"]];
+    self.repository = (LBPersistedModelRepository*)[adapter repositoryWithModelName:@"widgets"
+                                                                          persisted:YES];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testCreate {
+    LBPersistedModel __block *model = (LBPersistedModel*)[self.repository modelWithDictionary:@{ @"name": @"Foobar", @"bars": @1 }];
+
+    XCTAssertEqualObjects(@"Foobar", model[@"name"], @"Invalid name.");
+    XCTAssertEqualObjects(@1, model[@"bars"], @"Invalid bars.");
+    XCTAssertNil(model._id, @"Invalid id");
+
+    ASYNC_TEST_START
+    [model saveWithSuccess:^{
+        NSLog(@"Completed with: %@", model._id);
+        lastId = model._id;
+        XCTAssertNotNil(model._id, @"Invalid id");
+        ASYNC_TEST_SIGNAL
+    } failure:ASYNC_TEST_FAILURE_BLOCK];
+    ASYNC_TEST_END
+}
+
+- (void)testFind {
+    ASYNC_TEST_START
+    [self.repository findById:@2
+                       success:^(LBPersistedModel *model) {
+                           XCTAssertNotNil(model, @"No model found with ID 2");
+                           XCTAssertTrue([[model class] isSubclassOfClass:[LBModel class]], @"Invalid class.");
+                           XCTAssertEqualObjects(model[@"name"], @"Bar", @"Invalid name");
+                           XCTAssertEqualObjects(model[@"bars"], @1, @"Invalid bars");
+                           ASYNC_TEST_SIGNAL
+                       } failure:ASYNC_TEST_FAILURE_BLOCK];
+    ASYNC_TEST_END
+}
+
+- (void)testAll {
+    ASYNC_TEST_START
+    [self.repository allWithSuccess:^(NSArray *models) {
+        XCTAssertNotNil(models, @"No models returned.");
+        XCTAssertTrue([models count] >= 2, @"Invalid # of models returned: %lu", (unsigned long)[models count]);
+        XCTAssertTrue([[models[0] class] isSubclassOfClass:[LBModel class]], @"Invalid class.");
+        XCTAssertEqualObjects(models[0][@"name"], @"Foo", @"Invalid name");
+        XCTAssertEqualObjects(models[0][@"bars"], @0, @"Invalid bars");
+        XCTAssertEqualObjects(models[1][@"name"], @"Bar", @"Invalid name");
+        XCTAssertEqualObjects(models[1][@"bars"], @1, @"Invalid bars");
+        ASYNC_TEST_SIGNAL
+    } failure:ASYNC_TEST_FAILURE_BLOCK];
+    ASYNC_TEST_END
+}
+
+- (void)testUpdate {
+    ASYNC_TEST_START
+    LBPersistedModelFindSuccessBlock verify = ^(LBPersistedModel *model) {
+        XCTAssertNotNil(model, @"No model found with ID 2");
+        XCTAssertEqualObjects(model[@"name"], @"Barfoo", @"Invalid name");
+        XCTAssertEqualObjects(model[@"bars"], @1, @"Invalid bars");
+
+        model[@"name"] = @"Bar";
+        [model saveWithSuccess:^{
+            ASYNC_TEST_SIGNAL
+        } failure:ASYNC_TEST_FAILURE_BLOCK];
+    };
+
+    LBPersistedModelSaveSuccessBlock findAgain = ^() {
+        [self.repository findById:@2 success:verify failure:ASYNC_TEST_FAILURE_BLOCK];
+    };
+
+    LBPersistedModelFindSuccessBlock update = ^(LBPersistedModel *model) {
+        XCTAssertNotNil(model, @"No model found with ID 2");
+        model[@"name"] = @"Barfoo";
+        [model saveWithSuccess:findAgain failure:ASYNC_TEST_FAILURE_BLOCK];
+    };
+
+    [self.repository findById:@2 success:update failure:ASYNC_TEST_FAILURE_BLOCK];
+    ASYNC_TEST_END
+}
+
+- (void)testRemove {
+    ASYNC_TEST_START
+    [self.repository findById:lastId
+                      success:^(LBPersistedModel *model) {
+                          [model destroyWithSuccess:^{
+                              ASYNC_TEST_SIGNAL
+                          } failure:ASYNC_TEST_FAILURE_BLOCK];
+                      } failure:ASYNC_TEST_FAILURE_BLOCK];
+    ASYNC_TEST_END
+}
+
+
+@end


### PR DESCRIPTION
The model hierarchy is rearranged to reflect LB 2.0's.
Fixed `LBContainer` so that it doesn't use the Persisted Model's CRUD methods
(this breaks backward compatibility, but have to be fixed).

The followings are from Issue https://github.com/strongloop/loopback-sdk-ios/issues/40

Before the changes, all the LB model classes inherited `LBModel`, and `LBModel` supported CRUD operation.

[before]
```
LBModel --> LBUser, LBAccessToken, LBInstallation, LBFile, LBContainer
```
This PR introduces `LBPersistedModel` and makes the class hierarchy look like the below (consistent with the server side):

[after]
```
LBModel -+-> LBPersistedModel --> LBUser, LBAccessToken, LBInstallation
         |
         +-> LBFile, LBContainer
```

Also all the CRUD methods found in `LBModel` and `LBModelRepository` (those with leading * below -- just a few supported at this moment) has been moved to `LBPersistedModel` and `LBPersistedModelRepository` respectively:

```
LBModel
- (id)objectForKeyedSubscript:(id <NSCopying>)key;
- (void)setObject:(id)obj forKeyedSubscript:(id <NSCopying>)key;
- (NSDictionary *)toDictionary;
*- (void)saveWithSuccess:(LBModelSaveSuccessBlock)success failure:(SLFailureBlock)failure;
*- (void)destroyWithSuccess:(LBModelDestroySuccessBlock)success failure:(SLFailureBlock)failure;

LBModelRepository
- (SLRESTContract *)contract;
- (LBModel *)modelWithDictionary:(NSDictionary *)dictionary;
*- (void)findById:(id)_id success:(LBModelFindSuccessBlock)success failure:(SLFailureBlock)failure;
*- (void)allWithSuccess:(LBModelAllSuccessBlock)success failure:(SLFailureBlock)failure;
```