### PR TITLE
Import of MobileCoreServices improved for usage with CocoaPods. Mentioned in #46

### DIFF
--- a/LoopBack/LBFile.m
+++ b/LoopBack/LBFile.m
@@ -9,6 +9,10 @@
 #import "LBRESTAdapter.h"
 #import "SLStreamParam.h"
 
+#if TARGET_OS_IPHONE
+#import <MobileCoreServices/MobileCoreServices.h>
+#endif
+
 static NSString *mimeTypeForFileName(NSString *fileName) {
     CFStringRef pathExtension = (__bridge_retained CFStringRef)[fileName pathExtension];
     CFStringRef type = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension,

--- a/LoopBack/LoopBack-Prefix.pch
+++ b/LoopBack/LoopBack-Prefix.pch
@@ -3,5 +3,6 @@
 //
 
 #ifdef __OBJC__
+    #import <MobileCoreServices/MobileCoreServices.h>
     #import <SystemConfiguration/SystemConfiguration.h>
 #endif


### PR DESCRIPTION
As mentioned in #46  inside the  [Podspec Syntax Reference](http://guides.cocoapods.org/syntax/podspec.html#prefix_header_file) it's not recommended to use imports from the **LoopBack-Prefix.pch**.

> This attribute is not recommended as Pods should not pollute the prefix header of other libraries or of the user project.

Because **MobileCoreServices** are only used in **LBFile.m** I added the import there.

Best Lennart
