### PR TITLE
Import of MobileCoreServices in LBFile.m improved as mentioned in #46 (for usage with CocoaPods)

### DIFF
--- a/LoopBack/LBFile.m
+++ b/LoopBack/LBFile.m
@@ -5,6 +5,9 @@
  * @copyright (c) 2014 StrongLoop. All rights reserved.
  */
 
+#if TARGET_OS_IPHONE
+#import <MobileCoreServices/MobileCoreServices.h>
+#endif
 #import "LBFile.h"
 #import "LBRESTAdapter.h"
 #import "SLStreamParam.h"


### PR DESCRIPTION
As mentioned in #46  inside the  [Podspec Syntax Reference](http://guides.cocoapods.org/syntax/podspec.html#prefix_header_file) it's not recommended to use imports from the **LoopBack-Prefix.pch**.

> This attribute is not recommended as Pods should not pollute the prefix header of other libraries or of the user project.

Because **MobileCoreServices** are only used in **LBFile.m** I added the import there.

Best Lennart

Close #46
