### PR TITLE
Allow Obj-C property mapping to use primitive types for Number type

### DIFF
--- a/LoopBack/LBModel.m
+++ b/LoopBack/LBModel.m
@@ -96,16 +96,35 @@
 
     [[model _overflow] addEntriesFromDictionary:dictionary];
 
-    [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+    for (NSString *key in dictionary) {
+        id obj = dictionary[key];
         SEL setter = NSSelectorForSetter(key);
 
+        // if obj is a NSNumber (including a boolean value) try to use a setter for the primitive type
+        if ([obj isKindOfClass:[NSNumber class]]) {
+            NSMethodSignature *signature = [model methodSignatureForSelector:setter];
+            const char* type = [signature getArgumentTypeAtIndex:2];
+            if (type != NULL && type[0] != '@') { // if the setter is for a primitive type
+                NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+                [invocation setSelector:setter];
+                if (obj == (void*)kCFBooleanFalse || obj == (void*)kCFBooleanTrue) { // if boolean
+                    BOOL boolValue = [obj boolValue];
+                    [invocation setArgument:&boolValue atIndex:2];
+                } else {
+                    long integerValue = [obj integerValue];
+                    [invocation setArgument:&integerValue atIndex:2];
+                }
+                [invocation invokeWithTarget:model];
+                continue;
+            }
+        }
         if ([model respondsToSelector:setter]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
             [model performSelector:setter withObject:obj];
 #pragma clang diagnostic pop
         }
-    }];
+    };
 
     return model;
 }

--- a/LoopBackTests/LBPersistedModelSubclassingTests.m
+++ b/LoopBackTests/LBPersistedModelSubclassingTests.m
@@ -16,8 +16,12 @@ static NSNumber *lastId;
 @interface Widget : LBPersistedModel
 
 @property (nonatomic, copy) NSString *name;
+// a Number property can be accessed via either of NSNumber or the primitive type long.
 @property (nonatomic) NSNumber *bars;
-
+@property long bars2;
+// a Boolean property can be accessed via either of NSNumber or the primitive type BOOL.
+@property (nonatomic) NSNumber *flag;
+@property BOOL flag2;
 @end
 
 @implementation Widget
@@ -70,11 +74,30 @@ static NSNumber *lastId;
 }
 
 - (void)testCreate {
-    Widget *model = (Widget*)[self.repository modelWithDictionary:@{ @"name": @"Foobar", @"bars": @1 }];
+    Widget *model = (Widget*)[self.repository modelWithDictionary:@{
+        @"name" : @"Foobar",
+        @"bars" : @123,
+        @"bars2": @123,
+        @"flag" : @YES,
+        @"flag2": @YES
+    }];
 
-    XCTAssertEqualObjects(model.name, @"Foobar", @"Invalid name.");
-    XCTAssertEqualObjects(model.bars, @1, @"Invalid bars.");
     XCTAssertNil(model._id, @"Invalid id");
+    XCTAssertEqualObjects(model.name, @"Foobar", @"Invalid name.");
+    XCTAssertEqualObjects(model.bars, @123, @"Invalid bars.");
+    XCTAssertEqual(model.bars2, 123, @"Invalid bars2.");
+    XCTAssertEqualObjects(model.flag, @YES, @"Invalid flag.");
+    XCTAssertEqual(model.flag2, YES, @"Invalid flag2.");
+
+    model.bars = @456;
+    model.bars2 = 456;
+    model.flag = @NO;
+    model.flag2 = NO;
+
+    XCTAssertEqualObjects(model.bars, @456, @"Invalid bars.");
+    XCTAssertEqual(model.bars2, 456, @"Invalid bars2.");
+    XCTAssertEqualObjects(model.flag, @NO, @"Invalid flag.");
+    XCTAssertEqual(model.flag2, NO, @"Invalid flag2.");
 
     ASYNC_TEST_START
     [model saveWithSuccess:^{

--- a/LoopBackTests/server/index.js
+++ b/LoopBackTests/server/index.js
@@ -18,6 +18,18 @@ var Widget = app.model('widget', {
       type: Number,
       required: false
     },
+    bars2: {
+      type: Number,
+      required: false
+    },
+    flag: {
+      type: Boolean,
+      required: false
+    },
+    flag2: {
+      type: Boolean,
+      required: false
+    },
     data: {
       type: Object,
       required: false


### PR DESCRIPTION
This PR makes it possible to access a Number property using either of `NSNumber` or primitive type `long`.  It also enables a Boolean property access via either of `NSNumber` or primitive type `BOOL`

More discussions can be found in Issue #57.

@raymondfeng would you please review the changes?