### PR TITLE
Simplify [LBModel modelWithDictionary:] and fix memory leak in [LBModel toDictionary]

### DIFF
--- a/LoopBack/LBModel.m
+++ b/LoopBack/LBModel.m
@@ -56,6 +56,7 @@
                                                         encoding:NSUTF8StringEncoding];
             [dict setValue:[self valueForKey:propertyName] forKey:propertyName];
         }
+        free(properties);
     }
 
     return dict;

--- a/LoopBack/LBPersistedModel.m
+++ b/LoopBack/LBPersistedModel.m
@@ -25,7 +25,7 @@
 @synthesize _id = __id;
 
 - (void)setId:(id)_id {
-    __id = _id;
+    __id = [_id copy];
 }
 
 - (NSDictionary *)toDictionary {
@@ -41,7 +41,7 @@
     [self invokeMethod:self._id ? @"save" : @"create"
             parameters:[self toDictionary]
                success:^(id value) {
-                   __id = [[value valueForKey:@"id"] copy];
+                   [self setId:[value valueForKey:@"id"]];
                    success();
                }
                failure:failure];


### PR DESCRIPTION
I just realized that using Key-Value Coding the implementation can be simplified quite a bit.