### PR TITLE
Add support for Date type handling via NSDate

### DIFF
--- a/LoopBack/LBPersistedModel.m
+++ b/LoopBack/LBPersistedModel.m
@@ -25,7 +25,7 @@
 @synthesize _id = __id;
 
 - (void)setId:(id)_id {
-    __id = _id;
+    __id = [_id copy];
 }
 
 - (NSDictionary *)toDictionary {
@@ -41,7 +41,7 @@
     [self invokeMethod:self._id ? @"save" : @"create"
             parameters:[self toDictionary]
                success:^(id value) {
-                   __id = [[value valueForKey:@"id"] copy];
+                   [self setId:[value valueForKey:@"id"]];
                    success();
                }
                failure:failure];
@@ -83,6 +83,15 @@
             forMethod:[NSString stringWithFormat:@"%@.all", self.className]];
 
     return contract;
+}
+
+- (LBModel *)modelWithDictionary:(NSDictionary *)dictionary {
+    LBModel *model = [super modelWithDictionary:dictionary];
+    id obj = dictionary[@"id"];
+    if (obj) {
+        [(LBPersistedModel *)model setId:obj];
+    }
+    return model;
 }
 
 - (void)findById:(id)_id

--- a/LoopBackTests/server/index.js
+++ b/LoopBackTests/server/index.js
@@ -30,6 +30,10 @@ var Widget = app.model('widget', {
       type: Boolean,
       required: false
     },
+    date: {
+      type: Date,
+      required: false
+    },
     data: {
       type: Object,
       required: false
@@ -64,7 +68,8 @@ Widget.destroyAll(function () {
   });
   Widget.create({
     name: 'Bar',
-    bars: 1
+    bars: 1,
+    date: '2000-01-02T03:04:05.006Z'
   });
 });
 


### PR DESCRIPTION
This PR allows the developer to declare an NSDate property (instead of current NSString) to deal with the Date type.  Serialized JS Date will get deserialized and set to the NSDate property.
