### PR TITLE
Clean-up [<model-repository> repository] implementations and other minor improvements

### DIFF
--- a/LoopBack/LBAccessToken.m
+++ b/LoopBack/LBAccessToken.m
@@ -15,7 +15,6 @@
 
 + (instancetype)repository {
     LBAccessTokenRepository *repository = [self repositoryWithClassName:@"accessToken"];
-    repository.modelClass = [LBAccessToken class];
     return repository;
 }
 

--- a/LoopBack/LBContainer.m
+++ b/LoopBack/LBContainer.m
@@ -45,7 +45,6 @@
 
 + (instancetype)repository {
     LBContainerRepository *repository = [self repositoryWithClassName:@"containers"];
-    repository.modelClass = [LBContainer class];
     return repository;
 }
 

--- a/LoopBack/LBFile.m
+++ b/LoopBack/LBFile.m
@@ -86,7 +86,6 @@ static NSString *mimeTypeForFileName(NSString *fileName) {
 
 + (instancetype)repository {
     LBFileRepository *repository = [self repositoryWithClassName:@"containers"];
-    repository.modelClass = [LBFile class];
     return repository;
 }
 

--- a/LoopBack/LBInstallation.m
+++ b/LoopBack/LBInstallation.m
@@ -92,7 +92,6 @@
     @synchronized(self) {
         if(singleton == nil) {
             singleton = [self repositoryWithClassName:@"installations"];
-            singleton.modelClass = [LBInstallation class];
         }
     }
     return singleton;

--- a/LoopBack/LBPersistedModel.m
+++ b/LoopBack/LBPersistedModel.m
@@ -62,9 +62,8 @@
 @implementation LBPersistedModelRepository
 
 + (instancetype)repository {
-    LBPersistedModelRepository *repository = [self repositoryWithClassName:@"persistentmodels"];
-    repository.modelClass = [LBPersistedModel class];
-    return repository;
+    // LBPersistedModel won't get instantiated directly.
+    return nil;
 }
 
 - (SLRESTContract *)contract {

--- a/LoopBack/LBPersistedModel.m
+++ b/LoopBack/LBPersistedModel.m
@@ -50,7 +50,7 @@
 - (void)destroyWithSuccess:(LBPersistedModelDestroySuccessBlock)success
                    failure:(SLFailureBlock)failure {
     [self invokeMethod:@"remove"
-            parameters:[self toDictionary]
+            parameters:@{ @"id": self._id }
                success:^(id value) {
                    success();
                }

--- a/LoopBack/LBUser.m
+++ b/LoopBack/LBUser.m
@@ -33,7 +33,6 @@ static NSString * const DEFAULTS_CURRENT_USER_ID_KEY = @"LBUserRepositoryCurrent
 
 + (instancetype)repository {
     LBUserRepository *repository = [self repositoryWithClassName:@"users"];
-    repository.modelClass = [LBUser class];
     return repository;
 }
 

--- a/LoopBackTests/LBPersistedModelSubclassingTests.m
+++ b/LoopBackTests/LBPersistedModelSubclassingTests.m
@@ -16,9 +16,9 @@ static NSNumber *lastId;
 @interface Widget : LBPersistedModel
 
 @property (nonatomic, copy) NSString *name;
-// a Number property can be accessed via either of NSNumber or the primitive type long.
+// a Number property can be accessed via either of NSNumber or the primitive type NSInteger.
 @property (nonatomic) NSNumber *bars;
-@property long bars2;
+@property NSInteger bars2;
 // a Boolean property can be accessed via either of NSNumber or the primitive type BOOL.
 @property (nonatomic) NSNumber *flag;
 @property BOOL flag2;

--- a/LoopBackTests/LBPersistedModelTests.m
+++ b/LoopBackTests/LBPersistedModelTests.m
@@ -29,6 +29,9 @@ static NSNumber *lastId;
     [suite addTest:[self testCaseWithSelector:@selector(testCreate)]];
     [suite addTest:[self testCaseWithSelector:@selector(testFind)]];
     [suite addTest:[self testCaseWithSelector:@selector(testAll)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testFindWithFilter)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testFindOne)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testFindOneWithFilter)]];
     [suite addTest:[self testCaseWithSelector:@selector(testUpdate)]];
     [suite addTest:[self testCaseWithSelector:@selector(testRemove)]];
     return suite;
@@ -129,7 +132,6 @@ static NSNumber *lastId;
      } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END
 }
-
 
 - (void)testUpdate {
     ASYNC_TEST_START


### PR DESCRIPTION
Assignment to repository.modelClass is done in [LBModelRepository initWithClassName:] by obtaining the model class based on the repository class name.
Also, make sure that LBPersistedModel won't get instantiated directly.
