### PR TITLE
Necessary changes to support PersistedModel.updateAll

### DIFF
--- a/LoopBack/LBPersistedModel.h
+++ b/LoopBack/LBPersistedModel.h
@@ -7,6 +7,13 @@
 
 #import "LBModel.h"
 
+@class LBPersistedModel;
+typedef void (^LBPersistedModelObjectSuccessBlock)(LBPersistedModel *model);
+typedef void (^LBPersistedModelArraySuccessBlock)(NSArray *array);
+typedef void (^LBPersistedModelVoidSuccessBlock)();
+typedef void (^LBPersistedModelBoolSuccessBlock)(BOOL boolean);
+typedef void (^LBPersistedModelNumberSuccessBlock)(NSInteger number);
+
 /**
  * A local representative of a single persisted model instance on the server.
  * The key difference from LBModel is that this implements the CRUD operation supports.
@@ -20,7 +27,7 @@
  * Blocks of this type are executed when LBPersistedModel::saveWithSuccess:failure: is
  * successful.
  */
-typedef void (^LBPersistedModelSaveSuccessBlock)();
+typedef LBPersistedModelVoidSuccessBlock LBPersistedModelSaveSuccessBlock;
 /**
  * Saves the LBPersistedModel to the server.
  *
@@ -36,7 +43,7 @@ typedef void (^LBPersistedModelSaveSuccessBlock)();
  * Blocks of this type are executed when LBPersistedModel::destroyWithSuccess:failure: is
  * successful.
  */
-typedef void (^LBPersistedModelDestroySuccessBlock)();
+typedef LBPersistedModelVoidSuccessBlock LBPersistedModelDestroySuccessBlock;
 /**
  * Destroys the LBPersistedModel from the server.
  *
@@ -47,7 +54,6 @@ typedef void (^LBPersistedModelDestroySuccessBlock)();
                    failure:(SLFailureBlock)failure;
 
 @end
-
 
 /**
  * A local representative of a single model type on the server, encapsulating
@@ -67,7 +73,7 @@ typedef void (^LBPersistedModelDestroySuccessBlock)();
  * Blocks of this type are executed when
  * LBModelRepository::findById:success:failure: is successful.
  */
-typedef void (^LBPersistedModelFindSuccessBlock)(LBPersistedModel *model);
+typedef LBPersistedModelObjectSuccessBlock LBPersistedModelFindSuccessBlock;
 /**
  * Finds and downloads a single instance of this model type on and from the
  * server with the given id.
@@ -84,7 +90,7 @@ typedef void (^LBPersistedModelFindSuccessBlock)(LBPersistedModel *model);
  * Blocks of this type are executed when
  * LBPersistedModelRepository::allWithSuccess:failure: is successful.
  */
-typedef void (^LBPersistedModelAllSuccessBlock)(NSArray *models);
+typedef LBPersistedModelArraySuccessBlock LBPersistedModelAllSuccessBlock;
 /**
  * Finds and downloads all models of this type on and from the server.
  *
@@ -94,7 +100,7 @@ typedef void (^LBPersistedModelAllSuccessBlock)(NSArray *models);
 - (void)allWithSuccess:(LBPersistedModelAllSuccessBlock)success
                failure:(SLFailureBlock)failure;
 
-typedef void (^LBPersistedModelFindOneSuccessBlock)(LBPersistedModel *model);
+typedef LBPersistedModelObjectSuccessBlock LBPersistedModelFindOneSuccessBlock;
 - (void)findOneWithFilter:(NSDictionary *)filter
                   success:(LBPersistedModelFindOneSuccessBlock)success
                   failure:(SLFailureBlock)failure;

--- a/LoopBack/LBPersistedModel.m
+++ b/LoopBack/LBPersistedModel.m
@@ -39,7 +39,8 @@
 - (void)saveWithSuccess:(LBPersistedModelSaveSuccessBlock)success
                 failure:(SLFailureBlock)failure {
     [self invokeMethod:self._id ? @"save" : @"create"
-            parameters:[self toDictionary]
+            parameters:nil
+        bodyParameters:[self toDictionary]
                success:^(id value) {
                    [self setId:[value valueForKey:@"id"]];
                    success();

--- a/LoopBack/LBUser.m
+++ b/LoopBack/LBUser.m
@@ -71,7 +71,8 @@ static NSString * const DEFAULTS_CURRENT_USER_ID_KEY = @"LBUserRepositoryCurrent
     NSParameterAssert(email);
     NSParameterAssert(password);
     [self invokeStaticMethod:@"login"
-                  parameters:@{ @"email": email, @"password": password }
+                  parameters:nil
+              bodyParameters:@{ @"email": email, @"password": password }
                      success:^(id value) {
                          NSAssert([[value class] isSubclassOfClass:[NSDictionary class]], @"Received non-Dictionary: %@", value);
                          LBRESTAdapter* adapter = (LBRESTAdapter*)self.adapter;

--- a/LoopBackTests/LBPersistedModelTests.m
+++ b/LoopBackTests/LBPersistedModelTests.m
@@ -108,8 +108,11 @@ static NSNumber *lastId;
 
 - (void)testFindOne {
     ASYNC_TEST_START
-    [[self.repository adapter] invokeStaticMethod:@"widgets.findOne" parameters:
-     @{ @"filter": @{@"where": @{ @"name" : @"Foo" }}} success:^(LBPersistedModel *model) {
+    [[self.repository adapter] invokeStaticMethod:@"widgets.findOne"
+                                       parameters:@{ @"filter": @{@"where": @{ @"name" : @"Foo" }}}
+                                   bodyParameters:nil
+                                     outputStream:nil
+                                          success:^(LBPersistedModel *model) {
         XCTAssertNotNil(model, @"No models returned.");
         XCTAssertEqualObjects(model[@"name"], @"Foo", @"Invalid name");
         XCTAssertEqualObjects(model[@"bars"], @0, @"Invalid bars");

--- a/SLRemoting/SLAdapter.h
+++ b/SLRemoting/SLAdapter.h
@@ -110,26 +110,10 @@ extern NSString *SLAdapterNotConnectedErrorDescription;
  * Unlike SLAdapter::invokeInstanceMethod:constructorParameters:parameters:success:failure:,
  * no object needs to be created on the server.
  *
- * @param method      The method to invoke, e.g. `module.doSomething`.
- * @param parameters  The parameters to invoke with.
- * @param success     An SLSuccessBlock to be executed when the invocation
- *                    succeeds.
- * @param failure     An SLFailureBlock to be executed when the invocation
- *                    fails.
- */
-- (void)invokeStaticMethod:(NSString *)method
-                parameters:(NSDictionary *)parameters
-                   success:(SLSuccessBlock)success
-                   failure:(SLFailureBlock)failure;
-
-/**
- * Invokes a remotable method exposed statically on the server.
- *
- * Unlike SLAdapter::invokeInstanceMethod:constructorParameters:parameters:success:failure:,
- * no object needs to be created on the server.
- *
  * @param method        The method to invoke, e.g. `module.doSomething`.
  * @param parameters    The parameters to invoke with.
+ * @param bodyParameters  The parameters that get JSON encoded and put into
+ *                      the message body when the method is POST or PUT.
  * @param outputStream  The stream to which all the response data goes.
  *                      If this is set, no data is routed for further
  *                      processing and the success block is invoked with `nil`.
@@ -140,6 +124,7 @@ extern NSString *SLAdapterNotConnectedErrorDescription;
  */
 - (void)invokeStaticMethod:(NSString *)method
                 parameters:(NSDictionary *)parameters
+            bodyParameters:(NSDictionary *)bodyParameters
               outputStream:(NSOutputStream *)outputStream
                    success:(SLSuccessBlock)success
                    failure:(SLFailureBlock)failure;
@@ -158,31 +143,8 @@ extern NSString *SLAdapterNotConnectedErrorDescription;
  * @param constructorParameters  The parameters the virual object should be
  *                               created with.
  * @param parameters             The parameters to invoke with.
- * @param success                An SLSuccessBlock to be executed when the
- *                               invocation succeeds.
- * @param failure                An SLFailureBlock to be executed when the
- *                               invocation fails.
- */
-- (void)invokeInstanceMethod:(NSString *)method
-       constructorParameters:(NSDictionary *)constructorParameters
-                  parameters:(NSDictionary *)parameters
-                     success:(SLSuccessBlock)success
-                     failure:(SLFailureBlock)failure;
-
-/**
- * Invokes a remotable method exposed within a prototype on the server.
- *
- * This should be thought of as a two-step process. First, the server loads or
- * creates an object with the appropriate type. Then and only then is the method
- * invoked on that object. The two parameter dictionaries correspond to these
- * two steps: `creationParameters` for the former, and `parameters` for the
- * latter.
- *
- * @param method                 The method to invoke, e.g.
- *                               `MyClass.prototype.doSomething`.
- * @param constructorParameters  The parameters the virual object should be
- *                               created with.
- * @param parameters             The parameters to invoke with.
+ * @param bodyParameters         The parameters that get JSON encoded and put into
+ *                               the message body when the method is POST or PUT.
  * @param outputStream           The stream to which all the response data goes.
  *                               If this is set, no data is routed for further
  *                               processing and the success block is invoked
@@ -195,6 +157,7 @@ extern NSString *SLAdapterNotConnectedErrorDescription;
 - (void)invokeInstanceMethod:(NSString *)method
        constructorParameters:(NSDictionary *)constructorParameters
                   parameters:(NSDictionary *)parameters
+              bodyParameters:(NSDictionary *)bodyParameters
                 outputStream:(NSOutputStream *)outputStream
                      success:(SLSuccessBlock)success
                      failure:(SLFailureBlock)failure;

--- a/SLRemoting/SLAdapter.m
+++ b/SLRemoting/SLAdapter.m
@@ -60,30 +60,17 @@ NSString *SLAdapterNotConnectedErrorDescription = @"Adapter not connected.";
 
 - (void)invokeStaticMethod:(NSString *)path
                 parameters:(NSDictionary *)parameters
-                   success:(SLSuccessBlock)success
-                   failure:(SLFailureBlock)failure {
-    NSAssert(NO, @"Invalid Adapter.");
-}
-
-- (void)invokeStaticMethod:(NSString *)path
-                parameters:(NSDictionary *)parameters
+            bodyParameters:(NSDictionary *)bodyParameters
               outputStream:(NSOutputStream *)outputStream
                    success:(SLSuccessBlock)success
                    failure:(SLFailureBlock)failure {
     NSAssert(NO, @"Invalid Adapter.");
 }
 
-- (void)invokeInstanceMethod:(NSString *)path
-       constructorParameters:(NSDictionary *)constructorParameters
-                  parameters:(NSDictionary *)parameters
-                     success:(SLSuccessBlock)success
-                     failure:(SLFailureBlock)failure {
-    NSAssert(NO, @"Invalid Adapter.");
-}
-
 - (void)invokeInstanceMethod:(NSString *)method
        constructorParameters:(NSDictionary *)constructorParameters
                   parameters:(NSDictionary *)parameters
+              bodyParameters:(NSDictionary *)bodyParameters
                 outputStream:(NSOutputStream *)outputStream
                      success:(SLSuccessBlock)success
                      failure:(SLFailureBlock)failure {

--- a/SLRemoting/SLObject.h
+++ b/SLRemoting/SLObject.h
@@ -76,6 +76,28 @@ extern NSString *SLObjectInvalidRepositoryDescription;
  * Invokes a remotable method exposed within instances of this class on the
  * server.
  *
+ * @see SLAdapter::invokeInstanceMethod:constructorParameters:parameters:success:failure:
+ *
+ * @param name        The method to invoke (without the prototype), e.g.
+ *                    `doSomething`.
+ * @param parameters  The parameters to invoke with.
+ * @param bodyParameters  The parameters that get JSON encoded and put into
+ *                    the message body when the verb is POST or PUT.
+ * @param success     An SLSuccessBlock to be executed when the invocation
+ *                    succeeds.
+ * @param failure     An SLFailureBlock to be executed when the invocation
+ *                    fails.
+ */
+- (void)invokeMethod:(NSString *)name
+          parameters:(NSDictionary *)parameters
+      bodyParameters:(NSDictionary *)bodyParameters
+             success:(SLSuccessBlock)success
+             failure:(SLFailureBlock)failure;
+
+/**
+ * Invokes a remotable method exposed within instances of this class on the
+ * server.
+ *
  * @see SLAdapter::invokeInstanceMethod:constructorParameters:parameters:outputStream:success:failure:
  *
  * @param name          The method to invoke (without the prototype), e.g.
@@ -150,6 +172,28 @@ extern NSString *SLObjectInvalidRepositoryDescription;
  */
 - (void)invokeStaticMethod:(NSString *)name
                 parameters:(NSDictionary *)parameters
+                   success:(SLSuccessBlock)success
+                   failure:(SLFailureBlock)failure;
+
+/**
+ * Invokes a remotable method exposed statically within this class on the
+ * server.
+ *
+ * @see SLAdapter::invokeStaticMethod:parameters:success:failure:
+ *
+ * @param name        The method to invoke (without the class name), e.g.
+ *                    `doSomething`.
+ * @param parameters  The parameters to invoke with.
+ * @param bodyParameters  The parameters that get JSON encoded and put into
+ *                    the message body when the verb is POST or PUT.
+ * @param success     An SLSuccessBlock to be executed when the invocation
+ *                    succeeds.
+ * @param failure     An SLFailureBlock to be executed when the invocation
+ *                    fails.
+ */
+- (void)invokeStaticMethod:(NSString *)name
+                parameters:(NSDictionary *)parameters
+            bodyParameters:(NSDictionary *)bodyParameters
                    success:(SLSuccessBlock)success
                    failure:(SLFailureBlock)failure;
 

--- a/SLRemoting/SLObject.m
+++ b/SLRemoting/SLObject.m
@@ -52,10 +52,32 @@ NSString *SLObjectInvalidRepositoryDescription = @"Invalid repository.";
                       name];
 
     [self.repository.adapter invokeInstanceMethod:path
-                           constructorParameters:self.creationParameters
-                                      parameters:parameters
-                                         success:success
-                                         failure:failure];
+                            constructorParameters:self.creationParameters
+                                       parameters:parameters
+                                   bodyParameters:nil
+                                     outputStream:nil
+                                          success:success
+                                          failure:failure];
+}
+
+- (void)invokeMethod:(NSString *)name
+          parameters:(NSDictionary *)parameters
+      bodyParameters:(NSDictionary *)bodyParameters
+             success:(SLSuccessBlock)success
+             failure:(SLFailureBlock)failure {
+    NSAssert(self.repository, SLObjectInvalidRepositoryDescription);
+
+    NSString *path = [NSString stringWithFormat:@"%@.prototype.%@",
+                      self.repository.className,
+                      name];
+
+    [self.repository.adapter invokeInstanceMethod:path
+                            constructorParameters:self.creationParameters
+                                       parameters:parameters
+                                   bodyParameters:bodyParameters
+                                     outputStream:nil
+                                          success:success
+                                          failure:failure];
 }
 
 - (void)invokeMethod:(NSString *)name
@@ -73,6 +95,7 @@ NSString *SLObjectInvalidRepositoryDescription = @"Invalid repository.";
     [self.repository.adapter invokeInstanceMethod:path
                             constructorParameters:self.creationParameters
                                        parameters:parameters
+                                   bodyParameters:nil
                                      outputStream:outputStream
                                           success:success
                                           failure:failure];
@@ -108,6 +131,23 @@ NSString *SLObjectInvalidRepositoryDescription = @"Invalid repository.";
     NSString *path = [NSString stringWithFormat:@"%@.%@", self.className, name];
     [self.adapter invokeStaticMethod:path
                           parameters:parameters
+                      bodyParameters:nil
+                        outputStream:nil
+                             success:success
+                             failure:failure];
+}
+
+- (void)invokeStaticMethod:(NSString *)name
+                parameters:(NSDictionary *)parameters
+            bodyParameters:(NSDictionary *)bodyParameters
+                   success:(SLSuccessBlock)success
+                   failure:(SLFailureBlock)failure {
+
+    NSString *path = [NSString stringWithFormat:@"%@.%@", self.className, name];
+    [self.adapter invokeStaticMethod:path
+                          parameters:parameters
+                      bodyParameters:bodyParameters
+                        outputStream:nil
                              success:success
                              failure:failure];
 }
@@ -121,6 +161,7 @@ NSString *SLObjectInvalidRepositoryDescription = @"Invalid repository.";
     NSString *path = [NSString stringWithFormat:@"%@.%@", self.className, name];
     [self.adapter invokeStaticMethod:path
                           parameters:parameters
+                      bodyParameters:nil
                         outputStream:outputStream
                              success:success
                              failure:failure];

--- a/SLRemotingTests/SLRESTAdapterNonRootTests.m
+++ b/SLRemotingTests/SLRESTAdapterNonRootTests.m
@@ -33,6 +33,8 @@
     adapter = [SLRESTAdapter adapterWithURL:[NSURL URLWithString:@"http://localhost:3001/nonroot/api"]];
     [adapter invokeStaticMethod:@"getMsg"
                      parameters:nil
+                 bodyParameters:nil
+                   outputStream:nil
                         success:^(id value) {
                             XCTAssertNotNil(value, @"No value returned.");
                             XCTAssertTrue([@"Hello" isEqualToString:value[@"data"]], @"Incorrect value returned.");
@@ -48,6 +50,8 @@
     adapter = [SLRESTAdapter adapterWithURL:[NSURL URLWithString:@"http://localhost:3001/nonroot/api"]];
     [adapter invokeStaticMethod:@"convertMsg"
                      parameters:@{ @"str": @"somevalue" }
+                 bodyParameters:nil
+                   outputStream:nil
                         success:^(id value) {
                             XCTAssertNotNil(value, @"No value returned.");
                             XCTAssertTrue([@"CONVERTED: SOMEVALUE" isEqualToString:value[@"data"]], @"Incorrect value returned.");
@@ -63,6 +67,8 @@
     adapter = [SLRESTAdapter adapterWithURL:[NSURL URLWithString:@"http://localhost:3001/nonroot/api/"]];
     [adapter invokeStaticMethod:@"getMsg"
                      parameters:nil
+                 bodyParameters:nil
+                   outputStream:nil
                         success:^(id value) {
                             XCTAssertNotNil(value, @"No value returned.");
                             XCTAssertTrue([@"Hello" isEqualToString:value[@"data"]], @"Incorrect value returned.");
@@ -78,6 +84,8 @@
     adapter = [SLRESTAdapter adapterWithURL:[NSURL URLWithString:@"http://localhost:3001/nonroot/api/"]];
     [adapter invokeStaticMethod:@"convertMsg"
                      parameters:@{ @"str": @"somevalue" }
+                 bodyParameters:nil
+                   outputStream:nil
                         success:^(id value) {
                             XCTAssertNotNil(value, @"No value returned.");
                             XCTAssertTrue([@"CONVERTED: SOMEVALUE" isEqualToString:value[@"data"]], @"Incorrect value returned.");

--- a/SLRemotingTests/SLRESTAdapterSSLTests.m
+++ b/SLRemotingTests/SLRESTAdapterSSLTests.m
@@ -36,6 +36,8 @@
     ASYNC_TEST_START
     [adapter invokeStaticMethod:@"simple.getSecret"
                      parameters:nil
+                 bodyParameters:nil
+                   outputStream:nil
                         success:^(id value) {
                             XCTAssertNotNil(value, @"No value returned.");
                             XCTAssertTrue([@"shhh!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
@@ -49,6 +51,8 @@
     ASYNC_TEST_START
     [adapter invokeStaticMethod:@"simple.transform"
                      parameters:@{ @"str": @"somevalue" }
+                 bodyParameters:nil
+                   outputStream:nil
                         success:^(id value) {
                             XCTAssertNotNil(value, @"No value returned.");
                             XCTAssertTrue([@"transformed: somevalue" isEqualToString:value[@"data"]], @"Incorrect value returned.");
@@ -63,6 +67,8 @@
     [adapter invokeInstanceMethod:@"SimpleClass.prototype.getName"
             constructorParameters:@{ @"name": @"somename" }
                        parameters:nil
+                   bodyParameters:nil
+                     outputStream:nil
                           success:^(id value) {
                               XCTAssertNotNil(value, @"No value returned.");
                               XCTAssertTrue([@"somename" isEqualToString:value[@"data"]], @"Incorrect value returned.");
@@ -77,6 +83,8 @@
     [adapter invokeInstanceMethod:@"SimpleClass.prototype.greet"
             constructorParameters:@{ @"name": @"somename" }
                        parameters:@{ @"other": @"othername" }
+                   bodyParameters:nil
+                     outputStream:nil
                           success:^(id value) {
                               XCTAssertNotNil(value, @"No value returned.");
                               XCTAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], @"Incorrect value returned.");

--- a/SLRemotingTests/SLRESTAdapterTests.m
+++ b/SLRemotingTests/SLRESTAdapterTests.m
@@ -36,6 +36,8 @@
     ASYNC_TEST_START
     [adapter invokeStaticMethod:@"simple.getSecret"
                      parameters:nil
+                 bodyParameters:nil
+                   outputStream:nil
                         success:^(id value) {
                             XCTAssertNotNil(value, @"No value returned.");
                             XCTAssertTrue([@"shhh!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
@@ -49,6 +51,8 @@
     ASYNC_TEST_START
     [adapter invokeStaticMethod:@"simple.transform"
                      parameters:@{ @"str": @"somevalue" }
+                 bodyParameters:nil
+                   outputStream:nil
                         success:^(id value) {
                             XCTAssertNotNil(value, @"No value returned.");
                             XCTAssertTrue([@"transformed: somevalue" isEqualToString:value[@"data"]], @"Incorrect value returned.");
@@ -63,6 +67,8 @@
     [adapter invokeInstanceMethod:@"SimpleClass.prototype.getName"
             constructorParameters:@{ @"name": @"somename" }
                        parameters:nil
+                   bodyParameters:nil
+                     outputStream:nil
                           success:^(id value) {
                               XCTAssertNotNil(value, @"No value returned.");
                               XCTAssertTrue([@"somename" isEqualToString:value[@"data"]], @"Incorrect value returned.");
@@ -77,6 +83,8 @@
     [adapter invokeInstanceMethod:@"SimpleClass.prototype.greet"
             constructorParameters:@{ @"name": @"somename" }
                        parameters:@{ @"other": @"othername" }
+                   bodyParameters:nil
+                     outputStream:nil
                           success:^(id value) {
                               XCTAssertNotNil(value, @"No value returned.");
                               XCTAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
@@ -135,6 +143,7 @@
     ASYNC_TEST_START
     [adapter invokeStaticMethod:@"SimpleClass.binary"
                      parameters:nil
+                 bodyParameters:nil
                    outputStream:outputStream
                         success:^(id value) {
                             NSData *data =
@@ -155,6 +164,7 @@
     [adapter invokeInstanceMethod:@"SimpleClass.prototype.binary"
             constructorParameters:nil
                        parameters:nil
+                   bodyParameters:nil
                      outputStream:outputStream
                           success:^(id value) {
                               NSData *data =

--- a/SLRemotingTests/SLRESTContractTests.m
+++ b/SLRemotingTests/SLRESTContractTests.m
@@ -69,6 +69,8 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
     ASYNC_TEST_START
     [adapter invokeStaticMethod:@"contract.getSecret"
                      parameters:nil
+                 bodyParameters:nil
+                   outputStream:nil
                         success:^(id value) {
                             XCTAssertNotNil(value, @"No value returned.");
                             XCTAssertTrue([@"shhh!" isEqualToString:value[@"data"]], @"Incorrect value returned.");
@@ -82,6 +84,8 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
     ASYNC_TEST_START
     [adapter invokeStaticMethod:@"contract.transform"
                      parameters:@{ @"str": @"somevalue" }
+                 bodyParameters:nil
+                   outputStream:nil
                         success:^(id value) {
                             XCTAssertNotNil(value, @"No value returned.");
                             XCTAssertTrue([@"transformed: somevalue" isEqualToString:value[@"data"]], @"Incorrect value returned.");
@@ -96,6 +100,8 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
     [adapter invokeInstanceMethod:@"ContractClass.prototype.getName"
             constructorParameters:@{ @"name": @"somename" }
                        parameters:nil
+                   bodyParameters:nil
+                     outputStream:nil
                           success:^(id value) {
                               XCTAssertNotNil(value, @"No value returned.");
                               XCTAssertTrue([@"somename" isEqualToString:value[@"data"]], @"Incorrect value returned: %@", value);
@@ -110,6 +116,8 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
     [adapter invokeInstanceMethod:@"ContractClass.prototype.greet"
             constructorParameters:@{ @"name": @"somename" }
                        parameters:@{ @"other": @"othername" }
+                   bodyParameters:nil
+                     outputStream:nil
                           success:^(id value) {
                               XCTAssertNotNil(value, @"No value returned.");
                               XCTAssertTrue([@"Hi, othername!" isEqualToString:value[@"data"]], @"Incorrect value returned: %@", value);
@@ -171,6 +179,8 @@ static NSString * const SERVER_URL = @"http://localhost:3001";
 
     [customAdapter invokeStaticMethod:@"contract.getAuthorizationHeader"
                            parameters:nil
+                       bodyParameters:nil
+                         outputStream:nil
                               success:^(id value) {
                                   XCTAssertNotNil(value, @"No value returned.");
                                   XCTAssertTrue([@"auth-token" isEqualToString:value[@"data"]], @"Incorrect value returned.");


### PR DESCRIPTION
There are cases where some of the parameters go to the query string whereas the others go to the message body after JSON encoding.  One of such example is PersistedModel.updateAll:

https://github.com/strongloop/loopback/blob/32085475ed027f5a225e8023a69c98f1950cb7b9/lib/persisted-model.js#L635-L639
```
accepts: [
  {arg: 'where', type: 'object', http: {source: 'query'}, description: '...'},
  {arg: 'data', type: 'object', http: {source: 'body'}, description: '...'},
],
```
`where` has `http.source: query`, therefore it should be encoded into the query string.
`data` has `http.source: body`, therefore it should be encoded via AFJSONParameterEncoding and put into the request body.

However, the current `SLRESTAdapter`'s `invokeStaticMethod` and `invokeInstanceMethod` implementations don't support such parameter handling -- the both process all the parameters with AFJSONParameterEncoding when the verb is PUT or POST.

This PR introduces `jsonParameters` argument that explicitly specifies the parameters that need to go to the request body.

@raymondfeng would you please review the changes?