### PR TITLE
Remove redundant declarations of `+ (instancetype)repository`

### DIFF
--- a/LoopBack/LBAccessToken.h
+++ b/LoopBack/LBAccessToken.h
@@ -22,6 +22,4 @@
  */
 @interface LBAccessTokenRepository : LBPersistedModelRepository
 
-+ (instancetype)repository;
-
 @end

--- a/LoopBack/LBContainer.h
+++ b/LoopBack/LBContainer.h
@@ -54,8 +54,6 @@ typedef void (^LBContainerDeleteSuccessBlock)();
 /** Model repository for this container. */
 @property (nonatomic, readonly, strong) LBFileRepository *fileRepository;
 
-+ (instancetype)repository;
-
 /**
  * Blocks of this type are executed when
  * LBContainerRepository::createContainerWithName:success:failure: is successful.

--- a/LoopBack/LBFile.h
+++ b/LoopBack/LBFile.h
@@ -65,8 +65,6 @@ typedef void (^LBFileDeleteSuccessBlock)();
  */
 @interface LBFileRepository : LBModelRepository
 
-+ (instancetype)repository;
-
 /**
  * Creates a file with the given data
  *

--- a/LoopBack/LBInstallation.h
+++ b/LoopBack/LBInstallation.h
@@ -103,10 +103,5 @@
  */
 @interface LBInstallationRepository : LBPersistedModelRepository
 
-/**
- * Get a singleton for LBInstallationRepository
- */
-+ (instancetype)repository;
-
 @end
 

--- a/LoopBack/LBInstallation.m
+++ b/LoopBack/LBInstallation.m
@@ -87,6 +87,9 @@
 
 @implementation LBInstallationRepository
 
+/**
+ * Get a singleton for LBInstallationRepository
+ */
 + (instancetype)repository {
     static LBInstallationRepository *singleton = nil;
     @synchronized(self) {

--- a/LoopBack/LBModel.h
+++ b/LoopBack/LBModel.h
@@ -67,6 +67,14 @@
 @property Class modelClass;
 
 /**
+ * A method to be overriden by a subclass to create an adequately
+ * initialized repository of this type.
+ *
+ * @return  a new LBPersistedModelRepository subclass of this type.
+ */
++ (instancetype)repository;
+
+/**
  * The SLRESTContract representing this model type's custom routes. Used to
  * extend an Adapter to support this model type.
  *

--- a/LoopBack/LBModel.m
+++ b/LoopBack/LBModel.m
@@ -82,6 +82,12 @@ static NSDateFormatter *jsonDateFormatter = nil;
 
 @implementation LBModelRepository
 
++ (instancetype)repository {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"%s must be overridden appropriately in a subclass", __FUNCTION__]
+                                 userInfo:nil];
+}
+
 - (instancetype)initWithClassName:(NSString *)name {
     self = [super initWithClassName:name];
 

--- a/LoopBack/LBPersistedModel.h
+++ b/LoopBack/LBPersistedModel.h
@@ -62,8 +62,6 @@ typedef LBPersistedModelVoidSuccessBlock LBPersistedModelDestroySuccessBlock;
  */
 @interface LBPersistedModelRepository : LBModelRepository
 
-+ (instancetype)repository;
-
 //typedef void (^LBPersistedModelExistsSuccessBlock)(BOOL exists);
 //- (void)existsWithId:(id)_id
 //             success:(LBPersistedModelExistsSuccessBlock)success

--- a/LoopBack/LBPersistedModel.m
+++ b/LoopBack/LBPersistedModel.m
@@ -62,11 +62,6 @@
 
 @implementation LBPersistedModelRepository
 
-+ (instancetype)repository {
-    // LBPersistedModel won't get instantiated directly.
-    return nil;
-}
-
 - (SLRESTContract *)contract {
     SLRESTContract *contract = [super contract];
 

--- a/LoopBack/LBUser.h
+++ b/LoopBack/LBUser.h
@@ -32,8 +32,6 @@
 @property (nonatomic, readonly) NSString *currentUserId;
 @property (nonatomic, readonly) LBUser *cachedCurrentUser;
 
-+ (instancetype)repository;
-
 /**
  * Creates a user with the given credentials and additional data.
  *

--- a/LoopBackTests/LBPersistedModelSubclassingTests.m
+++ b/LoopBackTests/LBPersistedModelSubclassingTests.m
@@ -32,7 +32,6 @@ static NSNumber *lastId;
 @end
 
 @interface WidgetRepository : LBPersistedModelRepository
-+ (instancetype)repository;
 
 @end
 
@@ -43,6 +42,15 @@ static NSNumber *lastId;
 }
 
 @end
+
+@interface TestRepository : LBPersistedModelRepository
+
+@end
+
+@implementation TestRepository
+
+@end
+
 
 @interface LBPersistedModelSubclassingTests : XCTestCase
 
@@ -57,6 +65,7 @@ static NSNumber *lastId;
  */
 + (id)defaultTestSuite {
     XCTestSuite *suite = [XCTestSuite testSuiteWithName:@"TestSuite for LBPersistedModel subclasses."];
+    [suite addTest:[self testCaseWithSelector:@selector(testRepositoryNotOverridden)]];
     [suite addTest:[self testCaseWithSelector:@selector(testCreate)]];
     [suite addTest:[self testCaseWithSelector:@selector(testFind)]];
     [suite addTest:[self testCaseWithSelector:@selector(testAll)]];
@@ -74,6 +83,10 @@ static NSNumber *lastId;
 
 - (void)tearDown {
     [super tearDown];
+}
+
+- (void)testRepositoryNotOverridden {
+    XCTAssertThrows([TestRepository repository], @"Exception should be thrown as 'repository' is not overridden.");
 }
 
 - (void)testCreate {

--- a/LoopBackTests/LBUserTests.m
+++ b/LoopBackTests/LBUserTests.m
@@ -32,8 +32,6 @@ static NSString * const USER_PASSWORD = @"testpassword";
  */
 @interface CustomerRepository : LBUserRepository
 
-+ (instancetype)repository;
-
 @end
 
 @implementation CustomerRepository


### PR DESCRIPTION
Remove redundant declarations of `+ (instancetype)repository` scattered around LBModelRepository's subclasses. This clean-up is mainly for the codegen work.

@raymondfeng , would you please review the changes?
