### PR TITLE
Add missing MobileCoreServices and SystemConfiguration to Podspec

### DIFF
--- a/LoopBack.podspec
+++ b/LoopBack.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.ios.deployment_target = '6.1'
-  s.ios.frameworks = 'UIKit', 'Foundation'
+  s.ios.frameworks = 'UIKit', 'Foundation', 'MobileCoreServices', 'SystemConfiguration'
 
 end


### PR DESCRIPTION
The dependency on 'MobileCoreServices' and 'SystemConfiguration' frameworks has been introduced, but `LoopBack.podspec` was not updated reflecting it.  This PR fixes it.