### PR TITLE
test-server: fix Container's base class to Model

### DIFF
--- a/LoopBackTests/server/index.js
+++ b/LoopBackTests/server/index.js
@@ -48,15 +48,14 @@ var Installation = lbpn.Installation;
 Installation.attachTo(app.dataSources.Memory);
 app.model(Installation);
 
-var ds = loopback.createDataSource({
+var ds = app.dataSource('storage', {
   connector: require('loopback-component-storage'),
   provider: 'filesystem',
   root: path.join(__dirname, 'storage')
 });
 
-var container = ds.createModel('container');
-
-app.model(container);
+var container = loopback.createModel({ name: 'container', base: 'Model' });
+app.model(container, { dataSource: 'storage' });
 
 Widget.destroyAll(function () {
   Widget.create({


### PR DESCRIPTION
Rework the way how Container model is created to ensure it has Model (and not PersistedModel) as a base class.

This fixes a problem surfaced by https://github.com/strongloop/loopback/commit/40c5707a (see https://github.com/strongloop/loopback/commit/40c5707a#commitcomment-14525127) and makes the test "LBContainerTests :: testGetAll" pass.

/to @raymondfeng please review, you are most familiar with loopback-component-storage

@hideya Note that some other tests are still failing, it looks like method argument's mapping `body` is not honoured by our ios client - the container name for `createContainer` is send in the query string instead of the JSON body: `POST /containers?name=containerTest`.