### PR TITLE
Added resetPasswordWithEmail to trigger reset of the users password

### DIFF
--- a/LoopBack/LBUser.h
+++ b/LoopBack/LBUser.h
@@ -117,4 +117,21 @@ typedef void (^LBUserLogoutSuccessBlock)();
  */
 - (void)logoutWithSuccess:(LBUserLogoutSuccessBlock)success
                   failure:(SLFailureBlock)failure;
+
+/**
+ * Blocks of this type are executed when
+ * LBUserRepository::resetPasswordWithEmail:success:failure: is successful.
+ */
+typedef void (^LBUserResetSuccessBlock)();
+/**
+ * Triggers reset password for a user with email.
+ *
+ * @param email    The user email.
+ * @param success  The block to be executed when the reset is successful.
+ * @param failure  The block to be executed when the reset fails.
+ */
+- (void)resetPasswordWithEmail:(NSString*)email
+               success:(LBUserResetSuccessBlock)success
+               failure:(SLFailureBlock)failure;
+
 @end

--- a/LoopBack/LBUser.m
+++ b/LoopBack/LBUser.m
@@ -125,6 +125,19 @@ static NSString * const DEFAULTS_CURRENT_USER_ID_KEY = @"LBUserRepositoryCurrent
                      failure:failure];
 }
 
+- (void)resetPasswordWithEmail:(NSString*)email
+                       success:(LBUserResetSuccessBlock)success
+                       failure:(SLFailureBlock)failure {
+    NSParameterAssert(email);
+    [self invokeStaticMethod:@"reset"
+                  parameters:nil
+              bodyParameters:@{ @"email": email }
+                     success:^(id value) {
+                         success();
+                     }
+                     failure:failure];
+}
+
 - (NSString *)currentUserId {
     [self loadCurrentUserIdIfNotLoaded];
     return _currentUserId;

--- a/LoopBackTests/LBUserTests.m
+++ b/LoopBackTests/LBUserTests.m
@@ -63,6 +63,7 @@ typedef void (^GivenCustomerSuccessBlock)(Customer *customer);
     XCTestSuite *suite = [XCTestSuite testSuiteWithName:@"TestSuite for LBContainer."];
     [suite addTest:[self testCaseWithSelector:@selector(testCreateSaveRemove)]];
     [suite addTest:[self testCaseWithSelector:@selector(testLoginLogout)]];
+    [suite addTest:[self testCaseWithSelector:@selector(testResetPassword)]];
     [suite addTest:[self testCaseWithSelector:@selector(testSetsCurrentUserIdOnLogin)]];
     [suite addTest:[self testCaseWithSelector:@selector(testCurrentUserIdIsStoredInSharedPreferences)]];
     [suite addTest:[self testCaseWithSelector:@selector(testClearsCurrentUserIdOnLogout)]];
@@ -121,6 +122,16 @@ typedef void (^GivenCustomerSuccessBlock)(Customer *customer);
             [self.repository logoutWithSuccess:^(void) {
                 ASYNC_TEST_SIGNAL
             } failure:ASYNC_TEST_FAILURE_BLOCK];
+        } failure:ASYNC_TEST_FAILURE_BLOCK];
+    } failure:ASYNC_TEST_FAILURE_BLOCK];
+    ASYNC_TEST_END
+}
+
+- (void)testResetPassword {
+    ASYNC_TEST_START
+    [self givenCustomerWithSuccess:^(Customer *customer) {
+        [self.repository resetPasswordWithEmail:customer.email success:^{
+            ASYNC_TEST_SIGNAL
         } failure:ASYNC_TEST_FAILURE_BLOCK];
     } failure:ASYNC_TEST_FAILURE_BLOCK];
     ASYNC_TEST_END


### PR DESCRIPTION
This feature is currently missing, so you can't trigger the password reset request from the SDK.

https://docs.strongloop.com/display/public/LB/User+REST+API#UserRESTAPI-Resetpassword