### PR TITLE
Fix swift compatibility issue when init'ing a repo

### DIFF
--- a/LoopBack/LBAccessToken.h
+++ b/LoopBack/LBAccessToken.h
@@ -22,4 +22,6 @@
  */
 @interface LBAccessTokenRepository : LBPersistedModelRepository
 
++ (instancetype)repository;
+
 @end

--- a/LoopBack/LBContainer.h
+++ b/LoopBack/LBContainer.h
@@ -51,6 +51,8 @@ typedef void (^LBContainerDeleteSuccessBlock)();
  */
 @interface LBContainerRepository : LBModelRepository
 
++ (instancetype)repository;
+
 /** Model repository for this container. */
 @property (nonatomic, readonly, strong) LBFileRepository *fileRepository;
 

--- a/LoopBack/LBFile.h
+++ b/LoopBack/LBFile.h
@@ -65,6 +65,8 @@ typedef void (^LBFileDeleteSuccessBlock)();
  */
 @interface LBFileRepository : LBModelRepository
 
++ (instancetype)repository;
+
 /**
  * Creates a file with the given data
  *

--- a/LoopBack/LBInstallation.h
+++ b/LoopBack/LBInstallation.h
@@ -103,5 +103,7 @@
  */
 @interface LBInstallationRepository : LBPersistedModelRepository
 
++ (instancetype)repository;
+
 @end
 

--- a/LoopBack/LBModel.h
+++ b/LoopBack/LBModel.h
@@ -67,14 +67,6 @@
 @property Class modelClass;
 
 /**
- * A method to be overriden by a subclass to create an adequately
- * initialized repository of this type.
- *
- * @return  a new LBPersistedModelRepository subclass of this type.
- */
-+ (instancetype)repository;
-
-/**
  * The SLRESTContract representing this model type's custom routes. Used to
  * extend an Adapter to support this model type.
  *

--- a/LoopBack/LBModel.m
+++ b/LoopBack/LBModel.m
@@ -82,12 +82,6 @@ static NSDateFormatter *jsonDateFormatter = nil;
 
 @implementation LBModelRepository
 
-+ (instancetype)repository {
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:[NSString stringWithFormat:@"%s must be overridden appropriately in a subclass", __FUNCTION__]
-                                 userInfo:nil];
-}
-
 - (instancetype)initWithClassName:(NSString *)name {
     self = [super initWithClassName:name];
 

--- a/LoopBack/LBRESTAdapter.m
+++ b/LoopBack/LBRESTAdapter.m
@@ -48,10 +48,23 @@ static NSString * const DEFAULTS_ACCESSTOKEN_KEY = @"LBRESTAdapterAccessToken";
 }
 
 - (LBModelRepository *)repositoryWithClass:(Class)type {
-    NSParameterAssert(type);
-    NSParameterAssert([type isSubclassOfClass:[LBModelRepository class]]);
-    NSParameterAssert([type respondsToSelector:@selector(repository)]);
-
+    if (type == nil) {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                       reason:[NSString stringWithFormat:@"Argument cannot be nil"]
+                                     userInfo:nil];
+    }
+    if (![type isSubclassOfClass:[LBModelRepository class]]) {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                       reason:[NSString stringWithFormat:
+                                               @"Argument needs to be a subclass of LBModelRepository"]
+                                     userInfo:nil];
+    }
+    if (![type respondsToSelector:@selector(repository)]) {
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                       reason:[NSString stringWithFormat:
+                                               @"%@ must define 'repository' method", type]
+                                     userInfo:nil];
+    }
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-method-access"
     LBModelRepository *repository = (LBModelRepository *)[type repository];

--- a/LoopBack/LBUser.h
+++ b/LoopBack/LBUser.h
@@ -32,6 +32,8 @@
 @property (nonatomic, readonly) NSString *currentUserId;
 @property (nonatomic, readonly) LBUser *cachedCurrentUser;
 
++ (instancetype)repository;
+
 /**
  * Creates a user with the given credentials and additional data.
  *

--- a/LoopBackTests/LBPersistedModelSubclassingTests.m
+++ b/LoopBackTests/LBPersistedModelSubclassingTests.m
@@ -54,6 +54,7 @@ static NSNumber *lastId;
 
 @interface LBPersistedModelSubclassingTests : XCTestCase
 
+@property (nonatomic) LBRESTAdapter *adapter;
 @property (nonatomic) WidgetRepository *repository;
 
 @end
@@ -77,8 +78,8 @@ static NSNumber *lastId;
 - (void)setUp {
     [super setUp];
 
-    LBRESTAdapter *adapter = [LBRESTAdapter adapterWithURL:[NSURL URLWithString:@"http://localhost:3000"]];
-    self.repository = (WidgetRepository *)[adapter repositoryWithClass:[WidgetRepository class]];
+    self.adapter = [LBRESTAdapter adapterWithURL:[NSURL URLWithString:@"http://localhost:3000"]];
+    self.repository = (WidgetRepository *)[self.adapter repositoryWithClass:[WidgetRepository class]];
 }
 
 - (void)tearDown {
@@ -86,7 +87,8 @@ static NSNumber *lastId;
 }
 
 - (void)testRepositoryNotOverridden {
-    XCTAssertThrows([TestRepository repository], @"Exception should be thrown as 'repository' is not overridden.");
+    XCTAssertThrows([self.adapter repositoryWithClass:[TestRepository class]],
+        @"Exception should be thrown as 'repository' is not overridden.");
 }
 
 - (void)testCreate {


### PR DESCRIPTION
This fixes swift compatibility issue https://github.com/strongloop/loopback-sdk-ios/issues/86 reported by @kgoedecke.

Necessity to override `+[LBModelRepository repository]` turned out to be not compatible with swift because of the automatic mapping from Obj-C's factory method to swift's initializer.

Reverted most of PR #70. 
Instead, made to throw exceptions with appropriate explanation in `-[LBRESTAdapter repositoryWithClass:]`

@bajtos would you please review the changes?