### PR TITLE
Upload now passes HTTP response as LBFile into success callback

### DIFF
--- a/LoopBack/LBFile.h
+++ b/LoopBack/LBFile.h
@@ -20,7 +20,7 @@
  * Blocks of this type are executed when
  * LBFile:uploadWithSuccess:failure: is successful.
  */
-typedef void (^LBFileUploadSuccessBlock)();
+typedef void (^LBFileUploadSuccessBlock)(LBFile *file);
 /**
  * Uploads the file to the server.
  *

--- a/LoopBack/LBFile.m
+++ b/LoopBack/LBFile.m
@@ -40,15 +40,19 @@ static NSString *mimeTypeForFileName(NSString *fileName) {
                                                                           fileName:self.name
                                                                        contentType:mimeType
                                                                             length:length];
-
-   [self invokeMethod:@"upload"
-           parameters:@{ @"container": self.container,
-                         @"name": self.name,
-                         @"file": streamParam }
-              success:^(id value) {
-                  success();
-              }
-              failure:failure];
+    
+    [self invokeMethod:@"upload"
+            parameters:@{ @"container": self.container,
+                          @"name": self.name,
+                          @"file": streamParam }
+               success:^(id value) {
+                   NSAssert([[value class] isSubclassOfClass:[NSDictionary class]],
+                            @"Received non-Dictionary: %@", value);
+                   NSDictionary *fileDictionary = [(NSDictionary*)value valueForKeyPath:@"result.files.file"][0];
+                   LBFile *file = (LBFile *)[(LBFileRepository *)[self repository] modelWithDictionary:fileDictionary];
+                   success(file);
+               }
+               failure:failure];
 }
 
 - (void)downloadWithSuccess:(LBFileDownloadSuccessBlock)success
@@ -186,7 +190,11 @@ static NSString *mimeTypeForFileName(NSString *fileName) {
                                 @"container": container,
                                 @"file": streamParam }
                      success:^(id value) {
-                         success();
+                         NSAssert([[value class] isSubclassOfClass:[NSDictionary class]],
+                                  @"Received non-Dictionary: %@", value);
+                         NSDictionary *fileDictionary = [(NSDictionary*)value valueForKeyPath:@"result.files.file"][0];
+                         LBFile *file = (LBFile *)[self modelWithDictionary:fileDictionary];
+                         success(file);
                      }
                      failure:failure];
 }

--- a/LoopBackTests/LBFileTests.m
+++ b/LoopBackTests/LBFileTests.m
@@ -179,7 +179,10 @@
                                              localPath:tmpDir
                                              container:container];
     ASYNC_TEST_START
-    [file uploadWithSuccess:^() {
+    [file uploadWithSuccess:^(LBFile *fileReponse) {
+        XCTAssertEqualObjects(fileReponse.name, file.name);
+        XCTAssertEqualObjects(fileReponse.container, file.container);
+        
         [self.repository downloadAsDataWithName:fileName
                                       container:container
                                         success:^(NSData *data) {
@@ -206,7 +209,9 @@
                         inputStream:inputStream
                         contentType:@"text/plain"
                              length:bytes
-                            success:^() {
+                            success:^(LBFile *fileReponse) {
+                                XCTAssertEqualObjects(fileReponse.name, fileName);
+                                XCTAssertEqualObjects(fileReponse.container, container);
         [self.repository downloadAsDataWithName:fileName
                                       container:container
                                         success:^(NSData *data) {
@@ -230,7 +235,9 @@
                           container:container
                                data:data
                         contentType:@"text/plain"
-                            success:^() {
+                            success:^(LBFile *fileReponse) {
+                                XCTAssertEqualObjects(fileReponse.name, fileName);
+                                XCTAssertEqualObjects(fileReponse.container, container);
         [self.repository downloadAsDataWithName:fileName
                                       container:container
                                         success:^(NSData *data) {


### PR DESCRIPTION
As mentioned in issue https://github.com/strongloop/loopback-sdk-ios/issues/88 this PR enables uploads to pass the actual HTTP response as LBFile object into the success callback.

@hideya Can't wait for your feedback ;-)