### PR TITLE
Upload now passes HTTP response as LBFile into success callback

### DIFF
--- a/LoopBack/LBFile.h
+++ b/LoopBack/LBFile.h
@@ -20,7 +20,7 @@
  * Blocks of this type are executed when
  * LBFile:uploadWithSuccess:failure: is successful.
  */
-typedef void (^LBFileUploadSuccessBlock)();
+typedef void (^LBFileUploadSuccessBlock)(LBFile *file);
 /**
  * Uploads the file to the server.
  *

--- a/LoopBackTests/LBFileTests.m
+++ b/LoopBackTests/LBFileTests.m
@@ -179,7 +179,10 @@
                                              localPath:tmpDir
                                              container:container];
     ASYNC_TEST_START
-    [file uploadWithSuccess:^() {
+    [file uploadWithSuccess:^(LBFile *fileResponse) {
+        XCTAssertEqualObjects(fileResponse.name, file.name);
+        XCTAssertEqualObjects(fileResponse.container, file.container);
+        
         [self.repository downloadAsDataWithName:fileName
                                       container:container
                                         success:^(NSData *data) {
@@ -206,7 +209,9 @@
                         inputStream:inputStream
                         contentType:@"text/plain"
                              length:bytes
-                            success:^() {
+                            success:^(LBFile *fileResponse) {
+                                XCTAssertEqualObjects(fileResponse.name, fileName);
+                                XCTAssertEqualObjects(fileResponse.container, container);
         [self.repository downloadAsDataWithName:fileName
                                       container:container
                                         success:^(NSData *data) {
@@ -230,7 +235,9 @@
                           container:container
                                data:data
                         contentType:@"text/plain"
-                            success:^() {
+                            success:^(LBFile *fileResponse) {
+                                XCTAssertEqualObjects(fileResponse.name, fileName);
+                                XCTAssertEqualObjects(fileResponse.container, container);
         [self.repository downloadAsDataWithName:fileName
                                       container:container
                                         success:^(NSData *data) {


### PR DESCRIPTION
As mentioned in issue #88 this PR enables uploads to pass the actual HTTP response as LBFile object into the success callback.

@hideya Can't wait for your feedback ;-)