### PR TITLE
Add support for plain model creation

### DIFF
--- a/LoopBack/LBModel.h
+++ b/LoopBack/LBModel.h
@@ -75,6 +75,13 @@
 - (SLRESTContract *)contract;
 
 /**
+ * Creates a new LBModel of this type without setting initial parameters.
+ *
+ * @return  A new LBModel.
+ */
+- (LBModel *)model;
+
+/**
  * Creates a new LBModel of this type with the parameters described.
  *
  * @param  dictionary The data to encapsulate.

--- a/LoopBack/LBModel.m
+++ b/LoopBack/LBModel.m
@@ -104,8 +104,13 @@ static NSDateFormatter *jsonDateFormatter = nil;
     return contract;
 }
 
+- (LBModel *)model {
+    LBModel *model = (LBModel *)[[self.modelClass alloc] initWithRepository:self parameters:nil];
+    return model;
+}
+
 - (LBModel *)modelWithDictionary:(NSDictionary *)dictionary {
-    LBModel __block *model = (LBModel *)[[self.modelClass alloc] initWithRepository:self parameters:dictionary];
+    LBModel *model = (LBModel *)[[self.modelClass alloc] initWithRepository:self parameters:dictionary];
 
     [[model _overflow] addEntriesFromDictionary:dictionary];
 

--- a/LoopBackTests/LBModelTests.m
+++ b/LoopBackTests/LBModelTests.m
@@ -41,7 +41,7 @@
 }
 
 - (void)testSetObject {
-    LBModel *model = [self.repository modelWithDictionary:@{ @"name": @"Foo", @"bars": @123 }];
+    LBModel *model = [self.repository model];
 
     [model setObject:@"Bar" forKeyedSubscript:@"name"];
     [model setObject:@456 forKeyedSubscript:@"bars"];


### PR DESCRIPTION
This PR adds a method to create an `LBModel` object without setting initial parameters via dictionary.

When to create and initialise an object of a subclasses of `LBPersistedModel`, the following code would be a typical way. However, it is unnecessarily wordy:
```objc
Widget *model = (Widget*)[self.repository modelWithDictionary:nil];
model.name = @"Foo";
model.bars = 123;
```
This PR is to make the initialisation code simply like the following:
```objc
Widget *model = (Widget*)[self.repository model];
model.name = @"Foo";
model.bars = 123;
```
