### PR TITLE
Improve LBRESTAdapter repositoryWithModelName

### DIFF
--- a/LoopBack/LBRESTAdapter.h
+++ b/LoopBack/LBRESTAdapter.h
@@ -17,15 +17,23 @@
 @interface LBRESTAdapter : SLRESTAdapter
 
 /**
- * Returns a new LBModelRepository or LBPersistedModelRepository representing the named model type.
+ * Returns a new LBModelRepository representing the named model type.
  *
  * @param  name       The model name.
- * @param  persisted  A flag to specify `LBPersistedModelRepository` to be created.
- *                    `NO` to create a `LBModelRepository`.
  * @return            A new repository instance.
  */
+- (LBModelRepository *)repositoryWithModelName:(NSString *)name;
 
-- (LBModelRepository *)repositoryWithModelName:(NSString *)name persisted:(BOOL)persisted;
+/**
+ * Returns a new LBPersistedModelRepository representing the named model type.
+ *
+ * @param  name       The model name.
+ * @return            A new repository instance.
+ */
+- (LBPersistedModelRepository *)repositoryWithPersistedModelName:(NSString *)name;
+
+- (LBModelRepository *)repositoryWithModelName:(NSString *)name persisted:(BOOL)persisted
+    __attribute((deprecated("use repositoryWithModelName or repositoryWithPersistedModelName")));
 
 /**
  * Returns a new LBModelRepository from the given subclass.

--- a/LoopBack/LBRESTAdapter.m
+++ b/LoopBack/LBRESTAdapter.m
@@ -34,17 +34,29 @@ static NSString * const DEFAULTS_ACCESSTOKEN_KEY = @"LBRESTAdapterAccessToken";
     [self saveAccessToken:accessToken];
 }
 
-- (LBModelRepository *)repositoryWithModelName:(NSString *)name persisted:(BOOL)persisted {
+- (LBModelRepository *)repositoryWithModelName:(NSString *)name {
     NSParameterAssert(name);
 
-    LBModelRepository *repository = nil;
-    if (persisted) {
-        repository = [LBPersistedModelRepository repositoryWithClassName:name];
-    } else {
-        repository = [LBModelRepository repositoryWithClassName:name];
-    }
+    LBModelRepository *repository = [LBModelRepository repositoryWithClassName:name];
     [self attachRepository:repository];
     return repository;
+}
+
+- (LBPersistedModelRepository *)repositoryWithPersistedModelName:(NSString *)name {
+    NSParameterAssert(name);
+
+    LBPersistedModelRepository *repository = [LBPersistedModelRepository repositoryWithClassName:name];
+    [self attachRepository:repository];
+    return repository;
+}
+
+// The following method has been deprecated
+- (LBModelRepository *)repositoryWithModelName:(NSString *)name persisted:(BOOL)persisted {
+    if (persisted) {
+        return [self repositoryWithPersistedModelName:name];
+    } else {
+        return [self repositoryWithModelName:name];
+    }
 }
 
 - (LBModelRepository *)repositoryWithClass:(Class)type {

--- a/LoopBackTests/LBModelTests.m
+++ b/LoopBackTests/LBModelTests.m
@@ -22,7 +22,7 @@
     [super setUp];
 
     LBRESTAdapter *adapter = [LBRESTAdapter adapterWithURL:[NSURL URLWithString:@"http://localhost:3000"]];
-    self.repository = (LBModelRepository*)[adapter repositoryWithModelName:@"widgets" persisted:NO];
+    self.repository = [adapter repositoryWithModelName:@"widgets"];
 }
 
 - (void)tearDown {

--- a/LoopBackTests/LBPersistedModelTests.m
+++ b/LoopBackTests/LBPersistedModelTests.m
@@ -43,8 +43,7 @@ static NSNumber *lastId;
     [super setUp];
 
     LBRESTAdapter *adapter = [LBRESTAdapter adapterWithURL:[NSURL URLWithString:@"http://localhost:3000"]];
-    self.repository = (LBPersistedModelRepository*)[adapter repositoryWithModelName:@"widgets"
-                                                                          persisted:YES];
+    self.repository = [adapter repositoryWithPersistedModelName:@"widgets"];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
The method signature for `LBRESTAdapter repositoryWithModelName` was not well defined and this PR fixes it.  It used to have a `BOOL` flag `persisted` as an argument but this made its return type handling messy.  This PR introduces `repositoryWithPersistedModelName` method and eliminates the `BOOL` flag.  Since this is a braking change, the old API has been left with `deprecated` marked.

Before:
```objc
repo = [adapter repositoryWithModelName:@"widgets" persisted:NO];
persistedRepo = (LBPersistedModelRepository*)[adapter repositoryWithModelName:@"widgets" persisted:YES];
```
After:
```objc
repo = [adapter repositoryWithModelName:@"widgets"];
persistedRepo = [adapter repositoryWithPersistedModelName:@"widgets"];
```
@bajtos would you please review the changes?