### PR TITLE
Cleanup typedefs for success blocks, mark extra typedefs "deprecated"

### DIFF
--- a/LoopBack/LBModel.h
+++ b/LoopBack/LBModel.h
@@ -7,67 +7,6 @@
 
 #import "SLRemoting.h"
 
-/**
- * Blocks of this type are executed for a successful method invocation that doesn't return
- * any value as a callback argument.
- */
-typedef void (^LBModelVoidSuccessBlock)();
-
-/**
- * Blocks of this type are executed for a successful method invocation that returns
- * a BOOL value as a callback argument.
- */
-typedef void (^LBModelBoolSuccessBlock)(BOOL boolean);
-
-/**
- * Blocks of this type are executed for a successful method invocation that returns
- * an NSInteger value as a callback argument.
- */
-typedef void (^LBModelNumberSuccessBlock)(NSInteger number);
-
-/**
- * Blocks of this type are executed for a successful method invocation that returns
- * a NSString value as a callback argument.
- */
-typedef void (^LBModelStringSuccessBlock)(NSString *string);
-
-/**
- * Blocks of this type are executed for a successful method invocation that returns
- * an LBModel instance as a callback argument.
- */
-@class LBModel;
-typedef void (^LBModelObjectSuccessBlock)(LBModel *model);
-
-/**
- * Blocks of this type are executed for a successful method invocation that returns
- * an NSDictionary instance as a callback argument.
- */
-typedef void (^LBModelDictionarySuccessBlock)(NSDictionary *dictionary);
-
-/**
- * Blocks of this type are executed for a successful method invocation that returns
- * an NSArray instance as a callback argument.
- */
-typedef void (^LBModelArraySuccessBlock)(NSArray *array);
-
-/**
- * Blocks of this type are executed for a successful method invocation that returns
- * an NSDate instance as a callback argument.
- */
-typedef void (^LBModelDateSuccessBlock)(NSDate *date);
-
-/**
- * Blocks of this type are executed for a successful method invocation that returns
- * an NSData instance as a callback argument.
- */
-typedef void (^LBModelDataSuccessBlock)(NSData *data);
-
-/**
- * Blocks of this type are executed for a successful method invocation that returns
- * a CLLocation instance as a callback argument.
- */
-typedef void (^LBModelLocationSuccessBlock)(CLLocation *location);
-
 
 /**
  * A local representative of a single model instance on the server. The data is

--- a/LoopBack/LBPersistedModel.h
+++ b/LoopBack/LBPersistedModel.h
@@ -8,22 +8,13 @@
 #import "LBModel.h"
 
 
-/**
- * Blocks of this type are executed for a successful method invocation that returns
- * an LBPersistedModel instance as a callback argument.
- */
+// The following typedefs are not used anymore but left for backward compatibility.
 @class LBPersistedModel;
-typedef void (^LBPersistedModelObjectSuccessBlock)(LBPersistedModel *model);
-
-// The following typedefs are left for backward compatibility.
-typedef LBModelVoidSuccessBlock     LBPersistedModelVoidSuccessBlock
-        __attribute((deprecated("use LBModelVoidSuccessBlock")));
-typedef LBModelBoolSuccessBlock     LBPersistedModelBoolSuccessBlock
-        __attribute((deprecated("use LBModelBoolSuccessBlock")));
-typedef LBModelNumberSuccessBlock   LBPersistedModelNumberSuccessBlock
-        __attribute((deprecated("use LBModelNumberSuccessBlock")));
-typedef LBModelArraySuccessBlock    LBPersistedModelArraySuccessBlock
-        __attribute((deprecated("use LBModelArraySuccessBlock")));
+typedef void (^LBPersistedModelObjectSuccessBlock)(LBPersistedModel *model) __deprecated;
+typedef void (^LBPersistedModelArraySuccessBlock)(NSArray *array) __deprecated;
+typedef void (^LBPersistedModelVoidSuccessBlock)() __deprecated;
+typedef void (^LBPersistedModelBoolSuccessBlock)(BOOL boolean) __deprecated;
+typedef void (^LBPersistedModelNumberSuccessBlock)(NSInteger number) __deprecated;
 
 /**
  * A local representative of a single persisted model instance on the server.
@@ -38,7 +29,7 @@ typedef LBModelArraySuccessBlock    LBPersistedModelArraySuccessBlock
  * Blocks of this type are executed when LBPersistedModel::saveWithSuccess:failure: is
  * successful.
  */
-typedef LBModelVoidSuccessBlock LBPersistedModelSaveSuccessBlock;
+typedef void (^LBPersistedModelSaveSuccessBlock)();
 /**
  * Saves the LBPersistedModel to the server.
  *
@@ -54,7 +45,7 @@ typedef LBModelVoidSuccessBlock LBPersistedModelSaveSuccessBlock;
  * Blocks of this type are executed when LBPersistedModel::destroyWithSuccess:failure: is
  * successful.
  */
-typedef LBModelVoidSuccessBlock LBPersistedModelDestroySuccessBlock;
+typedef void (^LBPersistedModelDestroySuccessBlock)();
 /**
  * Destroys the LBPersistedModel from the server.
  *
@@ -82,7 +73,7 @@ typedef LBModelVoidSuccessBlock LBPersistedModelDestroySuccessBlock;
  * Blocks of this type are executed when
  * LBModelRepository::findById:success:failure: is successful.
  */
-typedef LBPersistedModelObjectSuccessBlock LBPersistedModelFindSuccessBlock;
+typedef void (^LBPersistedModelFindSuccessBlock)(LBPersistedModel *model);
 /**
  * Finds and downloads a single instance of this model type on and from the
  * server with the given id.
@@ -99,7 +90,7 @@ typedef LBPersistedModelObjectSuccessBlock LBPersistedModelFindSuccessBlock;
  * Blocks of this type are executed when
  * LBPersistedModelRepository::allWithSuccess:failure: is successful.
  */
-typedef LBModelArraySuccessBlock LBPersistedModelAllSuccessBlock;
+typedef void (^LBPersistedModelAllSuccessBlock)(NSArray *models);
 /**
  * Finds and downloads all models of this type on and from the server.
  *
@@ -109,7 +100,7 @@ typedef LBModelArraySuccessBlock LBPersistedModelAllSuccessBlock;
 - (void)allWithSuccess:(LBPersistedModelAllSuccessBlock)success
                failure:(SLFailureBlock)failure;
 
-typedef LBPersistedModelObjectSuccessBlock LBPersistedModelFindOneSuccessBlock;
+typedef void (^LBPersistedModelFindOneSuccessBlock)(LBPersistedModel *model);
 - (void)findOneWithFilter:(NSDictionary *)filter
                   success:(LBPersistedModelFindOneSuccessBlock)success
                   failure:(SLFailureBlock)failure;

--- a/LoopBackTests/LBPersistedModelSubclassingTests.m
+++ b/LoopBackTests/LBPersistedModelSubclassingTests.m
@@ -61,7 +61,7 @@ static NSNumber *lastId;
 }
 
 - (void)testMethodWithDate:(NSDate *)date
-                   success:(LBModelDateSuccessBlock)success
+                   success:(void (^)(NSDate *date))success
                    failure:(SLFailureBlock)failure {
 
     [self invokeStaticMethod:@"testDate"
@@ -76,7 +76,7 @@ static NSNumber *lastId;
 }
 
 - (void)testMethodWithData:(NSData *)data
-                   success:(LBModelDataSuccessBlock)success
+                   success:(void (^)(NSData *data))success
                    failure:(SLFailureBlock)failure {
 
     [self invokeStaticMethod:@"testBuffer"
@@ -91,7 +91,7 @@ static NSNumber *lastId;
 }
 
 - (void)testmethodWithLocation:(CLLocation *)location
-                       success:(LBModelLocationSuccessBlock)success
+                       success:(void (^)(CLLocation *location))success
                        failure:(SLFailureBlock)failure {
 
     [self invokeStaticMethod:@"testGeoPoint"


### PR DESCRIPTION
This performs the changes proposed in https://github.com/strongloop/loopback-sdk-ios/issues/99#issuecomment-182303989
This cleanups typedefs added after ver 1.3.2, marks extra typedefs "deprecated", but leaves the other legacy typedefs untouched.  At least this eliminates complications introduced after 1.3.2.
@bajtos would you please review the changes?