### PR TITLE
Minor cleanup in the run-unit-tests script

### DIFF
--- a/LoopBackTests/bin/run-unit-tests
+++ b/LoopBackTests/bin/run-unit-tests
@@ -26,19 +26,12 @@ node LoopBackTests/server/index.js &
 node SLRemotingTests/server/index.js &
 
 # run the unit tests on iPhone simulator
-DESTINATION_SIMULATOR='iPhone 6s'
-DESTINATION_SIMULATOR_CI='iPhone Retina (4-inch 64-bit)'
-# CI's xcode only has old simulators
-if [[ -n "${JENKINS_HOME}" ]]; then
-  DESTINATION_SIMULATOR=${DESTINATION_SIMULATOR_CI}
-fi
-
 xcodebuild \
   -verbose \
   -project LoopBack.xcodeproj \
   -scheme LoopBack \
   -sdk iphonesimulator \
-  -destination "platform=iOS Simulator,name=${DESTINATION_SIMULATOR},OS=latest" \
+  -destination 'platform=iOS Simulator,name=iPhone Retina (4-inch 64-bit),OS=latest' \
   ${XCODEBUILD_ARGS} \
   test
 


### PR DESCRIPTION
In a previous PR, I had a difficulty to run the Unit Tests on the same iPhone simulator that CI uses on my local machine (and added some conditional selection), but it turned out that it was because of an issue in my xcode environment (it got fixed by installing a new version).  Since it is better to use the same test environment as CI, I got rid of the conditional selection of the simulator.

@bajtos could you please review the changes?