### PR TITLE
Modified the LBModelRepository to allow filter responses with the inc…

### DIFF
--- a/LoopBack/LBModel.h
+++ b/LoopBack/LBModel.h
@@ -90,4 +90,11 @@
  */
 - (LBModel *)modelWithDictionary:(NSDictionary *)dictionary;
 
+/**
+ * Accesses the singleton dictionary of all model repositories
+ *
+ * @return      A dictionary of model
+ */
++ (NSMutableDictionary*) repositoriesDict;
+
 @end

--- a/LoopBack/LBModel.m
+++ b/LoopBack/LBModel.m
@@ -82,6 +82,9 @@
         if (!self.modelClass) {
             self.modelClass = [LBModel class];
         }
+        
+        // Add this repository to the dictionary of all repositories
+        [LBModelRepository.repositoriesDict setObject:self forKey:name];
     }
 
     return self;
@@ -130,6 +133,16 @@
                 else if (strncmp(type, "T@\"CLLocation\",", 15) == 0) {
                     obj = [SLObject locationFromEncodedProperty:obj];
                 }
+            } else if ([obj isKindOfClass:[NSArray class]])
+            {
+                LBModelRepository* repository = [LBModelRepository.repositoriesDict objectForKey:key];
+                NSMutableArray* tmp = [NSMutableArray array];
+                for (NSDictionary* dict in obj)
+                {
+                    LBModel* model = [repository modelWithDictionary:dict];
+                    [tmp addObject:model];
+                }
+                obj = tmp;
             }
 
             @try {
@@ -144,5 +157,15 @@
 
     return model;
 }
+
++ (NSMutableDictionary *) repositoriesDict {
+    static NSMutableDictionary *g_modelsDict = nil;
+    if (g_modelsDict == nil) {
+        // create dict
+        g_modelsDict = [[NSMutableDictionary alloc] init];
+    }
+    return g_modelsDict;
+}
+
 
 @end

--- a/LoopBack/LBPersistedModel.h
+++ b/LoopBack/LBPersistedModel.h
@@ -109,4 +109,8 @@ typedef void (^LBPersistedModelFindOneSuccessBlock)(LBPersistedModel *model);
                   success:(LBPersistedModelAllSuccessBlock)success
                   failure:(SLFailureBlock)failure;
 
+- (void)findWithFilterString:(NSString *) filter
+                  success: (LBPersistedModelAllSuccessBlock)success
+                  failure:(SLFailureBlock)failure;
+
 @end

--- a/LoopBack/LBPersistedModel.m
+++ b/LoopBack/LBPersistedModel.m
@@ -155,6 +155,26 @@
                      failure:failure];
 }
 
+- (void)findWithFilterString:(NSString *) filter
+               success: (LBPersistedModelAllSuccessBlock)success
+               failure:(SLFailureBlock)failure {
+    if(!filter) {
+        filter = @{};
+    }
+    [self invokeStaticMethod:@"find"
+                  parameters:@{@"filter": filter}
+                     success:^(id value) {
+                         NSAssert([[value class] isSubclassOfClass:[NSArray class]], @"Received non-Array: %@", value);
+                         
+                         NSMutableArray *models = [NSMutableArray array];
+                         [value enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+                             [models addObject:[self modelWithDictionary:obj]];
+                         }];
+                         
+                         success(models);
+                     }
+                     failure:failure];
+}
 
 
 @end


### PR DESCRIPTION
…lude filter to interpret arrays correctly.

I was trying to find a way to have the loopback-sdk-ios automatically include an NSArray of the appropriate model type when there was a filter request that had the "include" filter for a set of models with a hasMany relation. The attached pull request modifies the LBModelRepository to keep a global dictionary of the various repository objects and a modification of the modelWithDictionary to handle requests that have arrays of other model types.

Example usage:
(1) Create a model that not only has its own fields, but also an optional array that allows for the "include" filter:

``` swift
(Swift code)
class Customer : LBPersistedModel {
    var id: NSNumber!
    var customer_name: String!
    var customer_location_id: NSNumber!
    var user_closet_items: [Order]? = nil
}

class Order : LBPersistedModel {
  var id: NSNumber!
  var customer_id: NSNumber!
  var order_name: String!
}
```

(2) Create a CustomerRepository object and a OrderRepository object so that they are both known to the new global repositoryDictionary

(3) Execute a findWithFilter that includes a "include" filter

```
// Retrieve a limited list with includes
        AppDelegate.customerRepository.findWithFilter(["where":["id":3],"include":"orders"], success: { (objectList:[AnyObject]!) in
            print(objectList)

        }) { (err:NSError!) in
            print(err)
        }
```

(4) The objectList in Step (3) is a Customer model object that has the "orders" array populated with the associated orders. If the user had just done a query without the "include" filter then the "order" variable in the Customer model would have remained nil.
