### PR TITLE
Skip unit-tests on CI machines without xcodebuild

### DIFF
--- a/LoopBackTests/bin/run-unit-tests
+++ b/LoopBackTests/bin/run-unit-tests
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+uname -a
+if [ $CI ] && ! which xcodebuild; then
+  echo "xcodebuild not available, skipping unit tests"
+  exit 0
+fi
+
 set -ex
 trap 'kill $(jobs -p)' EXIT
 


### PR DESCRIPTION
Now that CIS uses devDependencies to trigger downstream builds, loopback-sdk-ios is triggered for pull requests in e.g. strong-remoting. Because the SDK requires `xcodebuild` to be installed, it fails on Linux-based CIS build slaves.

In this patch, I am adding a check to `run-unit-tests` script to skip the tests when `xcodebuild` is not available.

@rmg please review

cc @superkhau This is the only repository where we need ci.strongloop.com to run the tests on MacOSX. Ideally, the tests should be also triggered for pull requests in upstream repositories (loopback, strong-remoting, loopback-datasource-juggler, etc.).